### PR TITLE
add -Duse_LARGEFILE flag in FMS makefile

### DIFF
--- a/Makefile.cesm
+++ b/Makefile.cesm
@@ -63,7 +63,7 @@ endif
 # set CPP options (must use this before any flags or cflags settings)
 #===============================================================================
 
-CPPDEFS := $(USER_CPPDEFS) -D$(OS) -Duse_libMPI -Duse_netCDF -DSPMD -D__IFC
+CPPDEFS := $(USER_CPPDEFS) -D$(OS) -Duse_libMPI -Duse_netCDF -Duse_LARGEFILE -DSPMD -D__IFC
 
 # Unless DEBUG mode is enabled, use NDEBUG to turn off assert statements.
 ifneq ($(strip $(DEBUG)),TRUE)


### PR DESCRIPTION
Adds -Duse_LARGEFILE when compiling FMS. In absence of this cppdef, MOM6 fails with an IO error when in debug mode.

Note: a similar change is made in CIME for MOM6: https://github.com/ESMCI/cime/commit/c1bb32250a4a517f38e43cd7b97d8f5e3f837955