### PR TITLE
Fixes intel debug mode and gnu builds

### DIFF
--- a/Makefile.cesm
+++ b/Makefile.cesm
@@ -86,6 +86,22 @@ include $(CASEROOT)/Macros.make
 # autopromotion needed for FMS 
 FFLAGS += $(FC_AUTO_R8)
 
+# Additional GNU flags needed for FMS
+ifeq ($(strip $(COMPILER)),gnu)
+  FFLAGS += -fcray-pointer -fdefault-double-8
+  # also, below we inhibit all GNU compiler warnings for FMS because (1) we have no control
+  # over FMS, and (2) some GNU warning msgs contain characters that require encoding/decoding.
+  FFLAGS += -w
+  CFLAGS += -w
+endif
+
+# Disable the check for unallocated allocatable objects for FMS
+ifeq ($(strip $(DEBUG)),TRUE)
+  ifeq ($(strip $(COMPILER)),intel)
+    FFLAGS += -check nopointer
+  endif
+endif
+
 # Use this if LD has not already been defined.
 ifeq ($(origin LD), default)
   ifeq ($(strip $(MPILIB)),mpi-serial)
@@ -213,9 +229,8 @@ endif
 # This is needed so that dependancies are found
 VPATH+=$(CSM_SHR_INCLUDE)
 
-
-INCLDIR +=	-I$(INSTALL_SHAREDPATH)/include
-
+# Below includedir does not exist. Commenting out. -aa
+#INCLDIR +=	-I$(INSTALL_SHAREDPATH)/include
 
 FFLAGS += $(FPPDEFS)
 FFLAGS_NOOPT += $(FPPDEFS)

--- a/Makefile.cesm
+++ b/Makefile.cesm
@@ -229,9 +229,6 @@ endif
 # This is needed so that dependancies are found
 VPATH+=$(CSM_SHR_INCLUDE)
 
-# Below includedir does not exist. Commenting out. -aa
-#INCLDIR +=	-I$(INSTALL_SHAREDPATH)/include
-
 FFLAGS += $(FPPDEFS)
 FFLAGS_NOOPT += $(FPPDEFS)
 


### PR DESCRIPTION
List of changes:
- For intel compiler, adds ```-check nopointer``` flag in debug mode. Without this flag, the model does not compile in debug mode due to the presence of unallocated allocatable objects as subroutine args in FMS source code.
- For gnu compiler, adds the required flags ```-fcray-pointer``` and  ```-fdefault-double-8```.
- For gnu compiler, also inhibits all warnings (```-w```), because: (1) we have no control over FMS source code anyways, and (2) some GNU warning messages contain characters that cannot be decoded by Python 2, e.g., ```u'\u2018'```.