### PR TITLE
update fms tag to 2019.01.03

### DIFF
--- a/Externals_FMS.cfg
+++ b/Externals_FMS.cfg
@@ -1,5 +1,5 @@
 [fms]
-tag = xanadu
+tag = 2019.01.03
 protocol = git
 repo_url = https://github.com/NOAA-GFDL/FMS
 local_path = src


### PR DESCRIPTION
Update FMS tag from `xanadu` to `2019.01.03`. This upgrade is needed for NCAR MOM6 fork to proceed with merging GFDL's latest changes: https://github.com/NCAR/MOM6/pull/160

testing: aux_mom.cheyenne_intel

@jtruesdal Can you confirm that switching to this new FMS tag is okay for FV3?