### PR TITLE
Switch to FMS tag 2020.04.03

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,17 @@
 ===============================================================================
 Tag Creator: altuntas
 Developers:  altuntas
+Tag Date:    14 Apr 2021
+Tag Name:    fi_20210414
+
+FMS_interface Updates Summary:
+- update fms source tag to 2020.04.03
+
+Testing: aux_mom, cheyenne, b4b
+
+===============================================================================
+Tag Creator: altuntas
+Developers:  altuntas
 Tag Date:    12 Nov 2020
 Tag Name:    fi_20201112
 

--- a/Externals_FMS.cfg
+++ b/Externals_FMS.cfg
@@ -1,5 +1,5 @@
 [fms]
-tag = 2019.01.03
+tag = 2020.04.03
 protocol = git
 repo_url = https://github.com/NOAA-GFDL/FMS
 local_path = src

--- a/buildlib
+++ b/buildlib
@@ -73,7 +73,9 @@ def buildlib(bldroot, installpath, caseroot):
         gmake_opts += " -C {} ".format(installpath)
         gmake_opts += "CASEROOT={} ".format(caseroot)
         gmake_opts += "USER_INCLDIR=\"-I{} -I{} -I{}\"".format(os.path.join(fms_dir,"src","include"),
-                                                               os.path.join(fms_dir,"src","mpp","include"), os.path.join(bldroot,"FMS"))
+                                                               os.path.join(fms_dir,"src","fms2_io","include"),
+                                                               os.path.join(fms_dir,"src","mpp","include"),
+                                                               os.path.join(bldroot,"FMS") )
 
         gmake_opts += " COMPLIB=libfms.a "
         gmake_opts += get_standard_makefile_args(case)


### PR DESCRIPTION
This PR updates the FMS source tag to 2020.04.03. At this point, we will keep using FMS1 IO interface within CESM.

testing: aux_mom.cheyenne_{intel,gnu} b4b