### PR TITLE
Fix FMS build with Python 3.6+

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,18 @@
 ===============================================================================
 Tag Creator: altuntas
 Developers:  altuntas
+Tag Date:    19 Apr 2021
+Tag Name:    fi_20210419
+
+FMS_interface Updates Summary:
+- Fix FMS build for Python 3.6+
+- Update constants.F90 src_override for new FMS tag.
+
+Testing: aux_mom, cheyenne, b4b
+
+===============================================================================
+Tag Creator: altuntas
+Developers:  altuntas
 Tag Date:    14 Apr 2021
 Tag Name:    fi_20210414
 

--- a/buildlib
+++ b/buildlib
@@ -50,45 +50,46 @@ formatter_class=argparse.ArgumentDefaultsHelpFormatter
 
     return args.buildroot, args.installpath, args.caseroot
 
-def buildlib(bldroot, installpath, caseroot):
+def buildlib(bldroot, installpath, case):
 ###############################################################################
-    with Case(caseroot, read_only=False) as case:
-        srcroot = case.get_value("SRCROOT")
-        fms_dir = os.path.join(srcroot,"libraries","FMS")
-        if not os.path.isdir(os.path.join(bldroot,"FMS")):
-            os.makedirs(os.path.join(bldroot,"FMS"))
+    srcroot = case.get_value("SRCROOT")
+    caseroot = case.get_value("CASEROOT")
+    fms_dir = os.path.join(srcroot,"libraries","FMS")
+    if not os.path.isdir(os.path.join(bldroot,"FMS")):
+        os.makedirs(os.path.join(bldroot,"FMS"))
 
-        filepath = []
-        # put src_override directory at head of Filepath to use CESM interface versions of the FMS files.
-        filepath.append(os.path.join(fms_dir,"src_override"))
-        for _dir in glob.iglob(os.path.join(fms_dir,"src","*")):
-            if os.path.isdir(_dir) and not "cime_config" in _dir:
-                filepath.append(os.path.join(fms_dir, _dir))
-        with open(os.path.join(installpath,"Filepath"), "w") as fd:
-            for path in filepath:
-                fd.write(path+"\n")
-        # Tell mkSrcfiles to ignore files beginning in test_
-        os.environ["mkSrcfiles_skip_prefix"] = "test_"
-        gmake_opts = "-f {} ".format(os.path.join(fms_dir,"Makefile.cesm"))
-        gmake_opts += " -C {} ".format(installpath)
-        gmake_opts += "CASEROOT={} ".format(caseroot)
-        gmake_opts += "USER_INCLDIR=\"-I{} -I{} -I{}\"".format(os.path.join(fms_dir,"src","include"),
-                                                               os.path.join(fms_dir,"src","fms2_io","include"),
-                                                               os.path.join(fms_dir,"src","mpp","include"),
-                                                               os.path.join(bldroot,"FMS") )
+    filepath = []
+    # put src_override directory at head of Filepath to use CESM interface versions of the FMS files.
+    filepath.append(os.path.join(fms_dir,"src_override"))
+    for _dir in glob.iglob(os.path.join(fms_dir,"src","*")):
+        if os.path.isdir(_dir) and not "cime_config" in _dir:
+            filepath.append(os.path.join(fms_dir, _dir))
+    with open(os.path.join(installpath,"Filepath"), "w") as fd:
+        for path in filepath:
+            fd.write(path+"\n")
+    # Tell mkSrcfiles to ignore files beginning in test_
+    os.environ["mkSrcfiles_skip_prefix"] = "test_"
+    gmake_opts = "-f {} ".format(os.path.join(fms_dir,"Makefile.cesm"))
+    gmake_opts += " -C {} ".format(installpath)
+    gmake_opts += "CASEROOT={} ".format(caseroot)
+    gmake_opts += "USER_INCLDIR=\"-I{} -I{} -I{}\"".format(os.path.join(fms_dir,"src","include"),
+                                                           os.path.join(fms_dir,"src","fms2_io","include"),
+                                                           os.path.join(fms_dir,"src","mpp","include"),
+                                                           os.path.join(bldroot,"FMS") )
 
-        gmake_opts += " COMPLIB=libfms.a "
-        gmake_opts += get_standard_makefile_args(case)
-        gmake_cmd = case.get_value("GMAKE")
+    gmake_opts += " COMPLIB=libfms.a "
+    gmake_opts += get_standard_makefile_args(case)
+    gmake_cmd = case.get_value("GMAKE")
 
-        # This runs the FMS build
-        cmd = "{} {}".format(gmake_cmd, gmake_opts)
-        run_bld_cmd_ensure_logging(cmd, logger)
+    # This runs the FMS build
+    cmd = "{} {}".format(gmake_cmd, gmake_opts)
+    run_bld_cmd_ensure_logging(cmd, logger)
 
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)
-    buildlib(bldroot, installpath, caseroot)
+    with Case(caseroot) as case:
+        buildlib(bldroot, installpath, case)
 
 if (__name__ == "__main__"):
     _main(sys.argv, __doc__)

--- a/src_override/constants.F90
+++ b/src_override/constants.F90
@@ -39,12 +39,27 @@ public :: version
 
 real :: realnumber !< dummy variable to use in HUGE initializations
 
+!! The small_fac parameter is used to alter the radius of the earth to allow one to
+!! examine non-hydrostatic effects without the need to run full-earth high-resolution
+!! simulations (<13km) that will tax hardware resources.
+#ifdef SMALL_EARTH
+#if defined(DCMIP) || (defined(HIWPP) && defined(SUPER_K))
+ real, public, parameter :: small_fac =  1._r8_kind / 120._r8_kind   ! only needed for supercell test
+#elif defined(HIWPP)
+ real, public, parameter :: small_fac = 1._r8_kind / 166.7_r8_kind
+#else
+ real, public, parameter :: small_fac = 1._r8_kind / 10._r8_kind
+#endif
+#else
+ real, public, parameter :: small_fac = 1._r8_kind
+#endif
+
 #ifdef GFS_PHYS
 ! SJL: the following are from fv3_gfsphysics/gfs_physics/physics/physcons.f90
-real,               public, parameter :: RADIUS = 6.3712e+6_r8_kind           !< Radius of the Earth [m]
-real(kind=r8_kind), public, parameter :: PI_8   = 3.1415926535897931_r8_kind  !< Ratio of circle circumference to diameter [N/A]
-real,               public, parameter :: PI     = 3.1415926535897931_r8_kind  !< Ratio of circle circumference to diameter [N/A] (REAL(KIND=8))
-real,               public, parameter :: OMEGA  = 7.2921e-5_r8_kind   !< Rotation rate of the Earth [1/s]
+real,               public, parameter :: RADIUS = 6.3712e+6_r8_kind * small_fac !< Radius of the Earth [m]
+real(kind=r8_kind), public, parameter :: PI_8   = 3.1415926535897931_r8_kind    !< Ratio of circle circumference to diameter [N/A]
+real,               public, parameter :: PI     = 3.1415926535897931_r8_kind    !< Ratio of circle circumference to diameter [N/A]
+real,               public, parameter :: OMEGA  = 7.2921e-5_r8_kind / small_fac !< Rotation rate of the Earth [1/s]
 real,               public, parameter :: GRAV   = 9.80665_r8_kind     !< Acceleration due to gravity [m/s^2]
 real(kind=r8_kind), public, parameter :: GRAV_8 = 9.80665_r8_kind     !< Acceleration due to gravity [m/s^2] (REAL(KIND=8))
 real,               public, parameter :: RDGAS  = 287.05_r8_kind      !< Gas constant for dry air [J/kg/deg]
@@ -57,19 +72,8 @@ real,               public, parameter :: con_csol = 2.1060e+3_r8_kind !< spec he
 real,               public, parameter :: CP_AIR = 1004.6_r8_kind      !< Specific heat capacity of dry air at constant pressure [J/kg/deg]
 real,               public, parameter :: KAPPA  = RDGAS/CP_AIR        !< RDGAS / CP_AIR [dimensionless]
 real,               public, parameter :: TFREEZE = 273.15_r8_kind     !< Freezing temperature of fresh water [K]
-#else
 
-#ifdef SMALL_EARTH
-#if defined(DCMIP) || (defined(HIWPP) && defined(SUPER_K))
- real, private, parameter :: small_fac =  1._r8_kind / 120._r8_kind #only needed for supercell test
-#elif defined(HIWPP)
- real, private, parameter :: small_fac = 1._r8_kind / 166.7_r8_kind
 #else
- real, private, parameter :: small_fac = 1._r8_kind / 10._r8_kind
-#endif
-#else
- real, private, parameter :: small_fac = 1._r8_kind
-#endif
 
 real,         public, parameter :: RADIUS = 6371.0e+3_r8_kind * small_fac   !< Radius of the Earth [m]
 real(kind=8), public, parameter :: PI_8   = 3.14159265358979323846_r8_kind  !< Ratio of circle circumference to diameter [N/A]
@@ -89,7 +93,7 @@ real,         public, parameter :: TFREEZE = 273.16_r8_kind          !< Freezing
 real, public, parameter :: STEFAN  = 5.6734e-8_r8_kind !< Stefan-Boltzmann constant [W/m^2/deg^4]
 
 real, public, parameter :: CP_VAPOR = 4.0_r8_kind*RVGAS      !< Specific heat capacity of water vapor at constant pressure [J/kg/deg]
-real, public, parameter :: CP_OCEAN = 3989.24495292815_r8_kind !< Specific heat capacity taken from McDougall (2002) 
+real, public, parameter :: CP_OCEAN = 3989.24495292815_r8_kind !< Specific heat capacity taken from McDougall (2002)
                                                                !! "Potential Enthalpy ..." [J/kg/deg]
 real, public, parameter :: RHO0    = 1.035e3_r8_kind  !< Average density of sea water [kg/m^3]
 real, public, parameter :: RHO0R   = 1.0_r8_kind/RHO0 !< Reciprocal of average density of sea water [m^3/kg]
@@ -218,6 +222,18 @@ real(R8),   public, parameter :: RADCON_MKS  = (GRAV/CP_AIR)*SECONDS_PER_DAY !< 
 real(R8),   public, parameter :: O2MIXRAT    = 2.0953E-01_r8       !< Mixing ratio of molecular oxygen in air [dimensionless]
 real(R8),   public, parameter :: C2DBARS     = 1.e-4_r8            !< rho*g*z(mks) to dbars: 1dbar = 10^4 (kg/m^3)(m/s^2)m [dbars]
 real(R8),   public, parameter :: KELVIN      = 273.15_r8           !< Degrees Kelvin at zero Celsius [K]
+
+#ifdef SMALL_EARTH
+#if defined(DCMIP) || (defined(HIWPP) && defined(SUPER_K))
+ real, public, parameter :: small_fac =  1._r8 / 120._r8   ! only needed for supercell test
+#elif defined(HIWPP)
+ real, public, parameter :: small_fac = 1._r8 / 166.7_r8
+#else
+ real, public, parameter :: small_fac = 1._r8 / 10._r8
+#endif
+#else
+ real, public, parameter :: small_fac = 1._r8
+#endif
 
 #endif    ! ifdef USE_FMSCONST
 


### PR DESCRIPTION
This PR is an attempt to fix a build error reported by @mnlevy1981 :
> I'm getting the following error when trying to build FMS:

>$ cat /glade/scratch/mlevy/C1850MOMECO.064/bld/FMS.bldlog.210416-112703
>expected str, bytes or os.PathLike object, not Case

>This happened back when I first switched to cesm2_3_beta01, and the solution seemed to be to use an older >version of CIME (maybe 5.8.32 instead of 5.8.36?)...

I confirmed that this error occurs with Python 3.6+

A minor refactoring in buildlib appears to fix the issue. @mnlevy1981 , can you confirm that this also fixes the issue for you?

@jtruesdal , can you confirm that this does not impact FV3?

Once I get both confirmations, I will create a new FMS tag and add to cesm2_3_alpha02d

--------

Also, after reviews, I updated the constants file for the new FMS tag.