### PR TITLE
unset the mkSrcfiles_skip_prefix after build

### DIFF
--- a/buildlib
+++ b/buildlib
@@ -84,7 +84,7 @@ def buildlib(bldroot, installpath, case):
     # This runs the FMS build
     cmd = "{} {}".format(gmake_cmd, gmake_opts)
     run_bld_cmd_ensure_logging(cmd, logger)
-
+    del os.environ["mkSrcfiles_skip_prefix"]
 
 def _main(argv, documentation):
     bldroot, installpath, caseroot = parse_command_line(argv, documentation)


### PR DESCRIPTION
The env variable mkSrcfiles_skip_prefix defined in buildlib must be undefined when the build completes. 
Tested with PFS.ne30pg3z58_t061.B1850MOM.cheyenne_intel