### PR TITLE
Minor log fixes

### DIFF
--- a/src_override/mpp_io_misc.inc
+++ b/src_override/mpp_io_misc.inc
@@ -82,7 +82,7 @@
 
 
       outunit = stdout(); logunit=stdlog()
-      write(outunit, mpp_io_nml)
+      !write(outunit, mpp_io_nml)
       write(logunit, mpp_io_nml)
 
 !--- check the deflate level, set deflate = 1 if deflate_level is greater than equal to 0

--- a/src_override/mpp_util.inc
+++ b/src_override/mpp_util.inc
@@ -145,6 +145,7 @@
 !$  endif
 #ifdef CESMCOUPLED
     stdlog = stdout()
+    if (pe/=root_pe) stdlog = etc_unit
     return
 #endif
     if( pe.EQ.root_pe )then


### PR DESCRIPTION
Logging fixes complementary to the previously merged PR:
- Set `stdlog` to `etc_unit` if not in `rootpe` This is the original behavior in FMS. This prevents duplicate log writes.
- Don't write `mpp_io_nml` if not `rootpe`.