### PR TITLE
change date separator in filenames to '-', update bounds metadata

### DIFF
--- a/src_override/diag_output.F90
+++ b/src_override/diag_output.F90
@@ -1,0 +1,1360 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+!> @defgroup diag_output_mod diag_output_mod
+!> @ingroup diag_manager
+!! @brief diag_output_mod is an integral part of
+!!   diag_manager_mod. Its function is to write axis-meta-data,
+!!   field-meta-data and field data.
+!! @author Seth Underwood
+
+!> @file
+!> @brief File for @ref diag_output_mod
+
+!> @addtogroup diag_output_mod
+!> @{
+MODULE diag_output_mod
+
+use platform_mod
+use,intrinsic :: iso_fortran_env, only: real128
+use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
+                                      c_int32_t,c_int16_t,c_intptr_t
+! use_mpp_io = .false.
+  USE mpp_io_mod, ONLY: axistype, fieldtype, mpp_io_init, &
+       & mpp_get_id, MPP_WRONLY, MPP_OVERWR,&
+       & MPP_NETCDF, MPP_MULTI, MPP_SINGLE, mpp_get_field_name, &
+       & fillin_fieldtype
+  USE mpp_domains_mod, ONLY: domain1d, domain2d, mpp_define_domains, mpp_get_pelist,&
+       &  mpp_get_global_domain, mpp_get_compute_domains, null_domain1d, null_domain2d,&
+       & domainUG, null_domainUG, CENTER, EAST, NORTH, mpp_get_compute_domain,&
+       & OPERATOR(.NE.), mpp_get_layout, OPERATOR(.EQ.), mpp_get_io_domain, &
+       & mpp_get_compute_domain, mpp_get_global_domain
+  USE mpp_mod, ONLY: mpp_npes, mpp_pe, mpp_root_pe, mpp_get_current_pelist
+  USE diag_axis_mod, ONLY: diag_axis_init, get_diag_axis, get_axis_length,&
+       & get_axis_global_length, get_domain1d, get_domain2d, get_axis_aux, get_tile_count,&
+       & get_domainUG, get_diag_axis_name
+  USE diag_data_mod, ONLY: pack_size, diag_fieldtype, diag_global_att_type, CMOR_MISSING_VALUE, diag_atttype, files
+  USE time_manager_mod, ONLY: get_calendar_type, valid_calendar_types
+  USE fms_mod, ONLY: error_mesg, mpp_pe, write_version_number, fms_error_handler, FATAL, note
+
+#ifdef use_netCDF
+  USE netcdf, ONLY: NF90_INT, NF90_FLOAT, NF90_CHAR
+#endif
+
+  use mpp_domains_mod, only: mpp_get_UG_io_domain
+  use mpp_domains_mod, only: mpp_get_UG_domain_npes
+  use mpp_domains_mod, only: mpp_get_UG_domain_pelist
+  use mpp_mod,         only: mpp_gather
+  use mpp_mod,         only: uppercase,lowercase
+  use fms2_io_mod
+  use axis_utils2_mod,   only: axis_edges
+
+
+  IMPLICIT NONE
+
+  PRIVATE
+  PUBLIC :: diag_output_init, write_axis_meta_data, write_field_meta_data, done_meta_data,&
+       & diag_fieldtype, get_diag_global_att, set_diag_global_att
+  PUBLIC :: diag_field_write, diag_write_time !< use_mpp_io = .false.
+  TYPE(diag_global_att_type), SAVE :: diag_global_att
+
+  INTEGER, PARAMETER      :: NETCDF1 = 1
+  INTEGER, PARAMETER      :: mxch  = 128
+  INTEGER, PARAMETER      :: mxchl = 256
+  INTEGER                 :: current_file_unit = -1
+  INTEGER, DIMENSION(2,2) :: max_range = RESHAPE((/ -32767, 32767, -127,   127 /),(/2,2/))
+  INTEGER, DIMENSION(2)   :: missval = (/ -32768, -128 /)
+
+  INTEGER, PARAMETER      :: max_axis_num = 20
+  INTEGER                 :: num_axis_in_file = 0
+  INTEGER, DIMENSION(max_axis_num) :: axis_in_file
+  LOGICAL, DIMENSION(max_axis_num) :: time_axis_flag, edge_axis_flag
+  TYPE(axistype), DIMENSION(max_axis_num), SAVE :: Axis_types
+
+  LOGICAL :: module_is_initialized = .FALSE.
+
+  ! Include variable "version" to be written to log file.
+  character(len=*), parameter :: version = '2020.03'
+  !> @}
+
+  !> Write diag field using @ref fms2_io
+  !> @ingroup diag_output_mod
+  interface diag_field_write
+     module procedure diag_field_write_field
+     module procedure diag_field_write_varname
+  end interface
+
+  !> Initialize output for writing.
+  !> @ingroup diag_output_mod
+  interface diag_output_init
+     module procedure diag_output_init_fms2_io
+  end interface
+
+  !> Writes axis metadata to a file.
+  !> @ingroup diag_output_mod
+  interface write_axis_meta_data
+     module procedure write_axis_meta_data_fms2_io
+  end interface
+
+  !> Writes field metadata to a file.
+  !> @ingroup diag_output_mod
+  interface write_field_meta_data
+     module procedure write_field_meta_data_fms2_io
+  end interface
+
+  !> Private interface to write metadata for an attribute to a file.
+  !!
+  !> @note Added for mpp_io support
+  !> @ingroup diag_output_mod
+  interface write_attribute_meta
+     module procedure write_attribute_meta_fms2_io
+  end interface
+
+!> @addtogroup diag_output_mod
+!> @{
+CONTAINS
+
+  !> @brief Registers the time axis and opens the output file.
+  SUBROUTINE diag_output_init_fms2_io (file_name, FORMAT, file_title, file_unit,&
+       & all_scalar_or_1d, domain, domainU, fileobj, fileobjU, fileobjND, fnum_domain, &
+       & attributes)
+    CHARACTER(len=*), INTENT(in)  :: file_name !< Output file name
+    CHARACTER(len=*), INTENT(in)  :: file_title !< Descriptive title for the file
+    INTEGER         , INTENT(in)  :: FORMAT !< File format (Currently only 'NETCDF' is valid)
+    INTEGER         , INTENT(out) :: file_unit !< File unit number assigned to the output file.
+                                               !! Needed for subsuquent calls to
+                                               !! diag_output_mod
+    LOGICAL         , INTENT(in)  :: all_scalar_or_1d
+    TYPE(domain2d)  , INTENT(in)  :: domain
+    TYPE(diag_atttype), INTENT(in), DIMENSION(:), OPTIONAL :: attributes
+    TYPE(domainUG), INTENT(in)    :: domainU !< The unstructure domain
+    type(FmsNetcdfUnstructuredDomainFile_t),intent(inout),target :: fileobjU
+    type(FmsNetcdfDomainFile_t),intent(inout),target :: fileobj
+    type(FmsNetcdfFile_t),intent(inout),target :: fileobjND
+    class(FmsNetcdfFile_t), pointer :: fileob => NULL()
+    character(*),intent(out) :: fnum_domain
+    INTEGER :: form, threading, fileset, i
+    TYPE(diag_global_att_type) :: gAtt
+    character(len=:),allocatable :: fname_no_tile
+    integer :: len_file_name
+    integer, allocatable, dimension(:) :: current_pelist
+    integer :: mype  !< The pe you are on
+    character(len=9) :: mype_string !< a string to store the pe
+    !---- initialize mpp_io ----
+    IF ( .NOT.module_is_initialized ) THEN
+       CALL mpp_io_init ()
+       module_is_initialized = .TRUE.
+       CALL write_version_number("DIAG_OUTPUT_MOD", version)
+    END IF
+    !---- set up output file ----
+    SELECT CASE (FORMAT)
+    CASE (NETCDF1)
+       form      = MPP_NETCDF
+       threading = MPP_MULTI
+       fileset   = MPP_MULTI
+    CASE default
+       ! <ERROR STATUS="FATAL">invalid format</ERROR>
+       CALL error_mesg('diag_output_init', 'invalid format', FATAL)
+    END SELECT
+
+    IF(all_scalar_or_1d) THEN
+       threading = MPP_SINGLE
+       fileset   = MPP_SINGLE
+    END IF
+
+    len_file_name = len(trim(file_name))
+!> If the file name has .tileX or .tileX.nc where X is a one or two digit tile number, removes
+!! that suffix from the time name because fms2_io will add it
+!! \note If mpp_domains accepts more than 99 tiles, this will need to be updated
+    allocate(character(len=len_file_name) :: fname_no_tile)
+    if (len_file_name < 6) then
+       if (trim(file_name) == "tile") then
+          call error_mesg('diag_output_init', 'You can not name your history file "tile"',FATAL)
+       else
+          fname_no_tile = trim(file_name)
+       endif
+    !> One-digit tile numbers example
+    !! \verbatim
+    !! filename.tile1.nc
+    !!       09876543210
+    !!          ^  ^
+    !! filename.tile1
+    !!    09876543210
+    !!          ^  ^
+    !! \endverbatim
+    elseif (lowercase(file_name(len_file_name-4:len_file_name-1)) .eq. "tile") then
+       fname_no_tile = file_name(1:len_file_name-6)
+    elseif (len_file_name < 9) then
+       fname_no_tile = trim(file_name)
+    elseif (lowercase(file_name(len_file_name-7:len_file_name-4)) .eq. "tile") then
+       fname_no_tile = file_name(1:len_file_name-9)
+    !> Two-digit tile numbers example
+    !! \verbatim
+    !! filename.tile10.nc
+    !!        09876543210
+    !!          ^  ^
+    !! filename.tile10
+    !!     09876543210
+    !!          ^  ^
+    !! \endverbatim
+    elseif (lowercase(file_name(len_file_name-5:len_file_name-2)) .eq. "tile") then
+       fname_no_tile = file_name(1:len_file_name-7)
+
+    elseif (lowercase(file_name(len_file_name-5:len_file_name-8)) .eq. "tile") then
+       fname_no_tile = file_name(1:len_file_name-10)
+    else
+       fname_no_tile = trim(file_name)
+    endif
+!> If there is a .nc suffix on the file name, removes the .nc
+    if (len(trim(fname_no_tile)) > 3 ) then
+       checkNC: do i = 3,len(trim(fname_no_tile))
+         if (fname_no_tile(i-2:i) == ".nc") then
+            fname_no_tile(i-2:i) = "   "
+            exit checkNC
+         endif
+       enddo checkNC
+    endif
+
+!> Checks to make sure that only domain2D or domainUG is used.  If both are not null, then FATAL
+    if (domain .NE. NULL_DOMAIN2D .AND. domainU .NE. NULL_DOMAINUG)&
+          & CALL error_mesg('diag_output_init', "Domain2D and DomainUG can not be used at the same time in "//&
+          & trim(file_name), FATAL)
+
+    !---- open output file (return file_unit id) -----
+    IF ( domain .NE. NULL_DOMAIN2D ) THEN
+     !> Check if there is an io_domain
+     iF ( associated(mpp_get_io_domain(domain)) ) then
+       fileob => fileobj
+       if (.not.check_if_open(fileob)) call open_check(open_file(fileobj, trim(fname_no_tile)//".nc", "overwrite", &
+                            domain, is_restart=.false.))
+       fnum_domain = "2d" ! 2d domain
+       file_unit = 2
+     elSE !< No io domain, so every core is going to write its own file.
+       fileob => fileobjND
+       mype = mpp_pe()
+       write(mype_string,'(I0.4)') mype
+        if (.not.check_if_open(fileob)) then
+               call open_check(open_file(fileobjND, trim(fname_no_tile)//".nc."//trim(mype_string), "overwrite", &
+                            is_restart=.false.))
+               !< For regional subaxis add the NumFilesInSet attribute, which is added by fms2_io for (other)
+               !< domains with sufficient decomposition info. Note mppnccombine will work with an entry of zero.
+               call register_global_attribute(fileobjND, "NumFilesInSet", 0)
+       endif
+       fnum_domain = "nd" ! no domain
+       if (file_unit < 0) file_unit = 10
+     endiF
+    ELSE IF (domainU .NE. NULL_DOMAINUG) THEN
+       fileob => fileobjU
+       if (.not.check_if_open(fileob)) call open_check(open_file(fileobjU, trim(fname_no_tile)//".nc", "overwrite", &
+                            domainU, is_restart=.false.))
+       fnum_domain = "ug" ! unstructured grid
+       file_unit=3
+    ELSE
+       fileob => fileobjND
+!        if (.not.check_if_open(fileob) .and. mpp_pe() == mpp_root_pe()) then
+        allocate(current_pelist(mpp_npes()))
+        call mpp_get_current_pelist(current_pelist)
+        if (.not.check_if_open(fileob)) then
+               call open_check(open_file(fileobjND, trim(fname_no_tile)//".nc", "overwrite", &
+                            pelist=current_pelist, is_restart=.false.))
+        endif
+       fnum_domain = "nd" ! no domain
+       if (file_unit < 0) file_unit = 10
+       deallocate(current_pelist)
+    END IF
+
+    !---- write global attributes ----
+    IF ( file_title(1:1) /= ' ' ) THEN
+       call register_global_attribute(fileob, 'title', TRIM(file_title), str_len=len_trim(file_title))
+    END IF
+
+    IF ( PRESENT(attributes) ) THEN
+       DO i=1, SIZE(attributes)
+          SELECT CASE (attributes(i)%type)
+          CASE (NF90_INT)
+             call register_global_attribute(fileob, TRIM(attributes(i)%name), attributes(i)%iatt)
+          CASE (NF90_FLOAT)
+
+             call register_global_attribute(fileob, TRIM(attributes(i)%name), attributes(i)%fatt)
+          CASE (NF90_CHAR)
+
+             call register_global_attribute(fileob, TRIM(attributes(i)%name), attributes(i)%catt, str_len=len_trim(attributes(i)%catt))
+          CASE default
+             ! <ERROR STATUS="FATAL">
+             !   Unknown attribute type for attribute <name> to module/input_field <module_name>/<field_name>.
+             !   Contact the developers.
+             ! </ERROR>
+             CALL error_mesg('diag_output_mod::diag_output_init', 'Unknown attribute type for global attribute "'&
+                  &//TRIM(attributes(i)%name)//'" in file "'//TRIM(file_name)//'". Contact the developers.', FATAL)
+          END SELECT
+       END DO
+    END IF
+    !---- write grid type (mosaic or regular)
+    CALL get_diag_global_att(gAtt)
+
+    call register_global_attribute(fileob, 'grid_type', TRIM(gAtt%grid_type), str_len=len_trim(gAtt%grid_type))
+
+    call register_global_attribute(fileob, 'grid_tile', TRIM(gAtt%tile_name), str_len=len_trim(gAtt%tile_name))
+
+  END SUBROUTINE diag_output_init_fms2_io
+
+  !> @brief Write the axis meta data to file.
+  SUBROUTINE write_axis_meta_data_fms2_io(file_unit, axes, fileob, time_ops, time_axis_registered)
+    INTEGER, INTENT(in) :: file_unit !< File unit number
+    INTEGER, INTENT(in) :: axes(:) !< Array of axis ID's, including the time axis
+    class(FmsNetcdfFile_t) , intent(inout),target :: fileob
+    class(FmsNetcdfFile_t) ,pointer                        :: fptr
+    LOGICAL, INTENT(in), OPTIONAL :: time_ops !< .TRUE. if this file contains any min, max, time_rms, or time_average
+    logical, intent(inout) , optional :: time_axis_registered
+    TYPE(domain1d)       :: Domain
+
+    TYPE(domainUG)       :: domainU
+
+    CHARACTER(len=mxch)  :: axis_name, axis_units, axis_name_current
+    CHARACTER(len=mxchl) :: axis_long_name
+    CHARACTER(len=1)     :: axis_cart_name
+    INTEGER              :: axis_direction, axis_edges
+    REAL, ALLOCATABLE    :: axis_data(:)
+    INTEGER, ALLOCATABLE :: axis_extent(:), pelist(:)
+integer :: domain_size, axis_length, axis_pos
+    INTEGER              :: num_attributes
+    TYPE(diag_atttype), DIMENSION(:), ALLOCATABLE :: attributes
+    INTEGER              :: calendar, id_axis, id_time_axis
+    INTEGER              :: i, j, index, num, length, edges_index
+    INTEGER              :: gbegin, gend, gsize, ndivs
+    LOGICAL              :: time_ops1
+    CHARACTER(len=2048)  :: err_msg
+    type(domainUG),pointer                     :: io_domain
+    integer(I4_KIND)                          :: io_domain_npes
+    integer(I4_KIND),dimension(:),allocatable :: io_pelist
+    integer(I4_KIND),dimension(:),allocatable :: unstruct_axis_sizes
+    real,dimension(:),allocatable              :: unstruct_axis_data
+    integer                                    :: id_axis_current
+    logical :: is_time_axis_registered
+    integer :: istart, iend
+    integer :: gstart, cstart, cend !< Start and end of global and compute domains
+    integer :: clength !< Length of compute domain
+    integer :: data_size
+    integer, allocatable, dimension(:) :: all_indicies
+    character(len=32) :: type_str !< Str indicating the type of the axis data
+
+    ! Make sure err_msg is initialized
+    err_msg = ''
+    fptr => fileob !Use for selecting a type
+    IF ( PRESENT(time_ops) ) THEN
+       time_ops1 = time_ops
+    ELSE
+       time_ops1 = .FALSE.
+    END IF
+    if (present(time_axis_registered)) then
+     is_time_axis_registered = time_axis_registered
+    else
+     is_time_axis_registered = .false.
+    endif
+    !---- save the current file_unit ----
+    IF ( num_axis_in_file == 0 ) current_file_unit = file_unit
+
+    !---- dummy checks ----
+    num = SIZE(axes(:))
+    ! <ERROR STATUS="FATAL">number of axes < 1 </ERROR>
+    IF ( num < 1 ) CALL error_mesg('write_axis_meta_data', 'number of axes < 1.', FATAL)
+
+    ! <ERROR STATUS="FATAL">writing meta data out-of-order to different files.</ERROR>
+    IF ( file_unit /= current_file_unit ) CALL error_mesg('write_axis_meta_data',&
+         & 'writing meta data out-of-order to different files.', FATAL)
+
+    IF (pack_size .eq. 1) then
+       type_str = "double"
+    ELSE IF (pack_size .eq. 2) then
+       type_str = "float"
+    ENDIF
+
+    !---- check all axes ----
+    !---- write axis meta data for new axes ----
+    DO i = 1, num
+       id_axis = axes(i)
+       index = get_axis_index ( id_axis )
+
+       !---- skip axes already written -----
+       IF ( index > 0 ) CYCLE
+
+       !---- create new axistype (then point to) -----
+       num_axis_in_file = num_axis_in_file + 1
+       axis_in_file(num_axis_in_file) = id_axis
+       edge_axis_flag(num_axis_in_file) = .FALSE.
+       length = get_axis_global_length(id_axis)
+       ALLOCATE(axis_data(length))
+
+       CALL get_diag_axis(id_axis, axis_name, axis_units, axis_long_name,&
+            & axis_cart_name, axis_direction, axis_edges, Domain, DomainU, axis_data,&
+            & num_attributes, attributes, domain_position=axis_pos)
+
+       IF ( Domain .NE. null_domain1d ) THEN
+          IF ( length > 0 ) THEN
+             if (trim(uppercase(trim(axis_cart_name))) .eq. "X" .or. trim(uppercase(trim(axis_cart_name))) .eq. "Y") then
+                  select type (fptr)
+                    type is (FmsNetcdfDomainFile_t)
+                         call register_axis(fptr, axis_name, lowercase(trim(axis_cart_name)), domain_position=axis_pos )
+                      if (allocated(fptr%pelist)) then
+                         call get_global_io_domain_indices(fptr, trim(axis_name), istart, iend)
+                         call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                         if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                         call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                         call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                         select case (axis_direction)
+                              case (1)
+                                   call register_variable_attribute(fptr, axis_name, "positive", "up", str_len=len_trim("up"))
+                              case (-1)
+                                   call register_variable_attribute(fptr, axis_name, "positive", "down", str_len=len_trim("down"))
+                         end select
+                         call write_data(fptr, axis_name, axis_data(istart:iend) )
+                      endif
+                    type is (FmsNetcdfFile_t) !< For regional X and Y axes, treat as any other axis
+                         call mpp_get_global_domain(domain, begin=gstart, end=gend)  !< Get the global indicies
+                         call mpp_get_compute_domain(domain, begin=cstart, end=cend, size=clength) !< Get the compute indicies
+                         iend =  cend - gstart + 1     !< Get the array indicies for the axis data
+                         istart = cstart - gstart + 1
+                         call register_axis(fptr, axis_name, dimension_length=clength)
+                         call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                         call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                         call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                         call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                         select case (axis_direction)
+                              case (1)
+                                   call register_variable_attribute(fptr, axis_name, "positive", "up", str_len=len_trim("up"))
+                              case (-1)
+                                   call register_variable_attribute(fptr, axis_name, "positive", "down", str_len=len_trim("down"))
+                         end select
+                         !< For regional subaxis add the "domain_decomposition" attribute, which is added
+                         !< fms2_io for (other) domains with sufficient decomposition info.
+                         call register_variable_attribute(fptr, axis_name, "domain_decomposition", &
+                              (/gstart, gend, cstart, cend/))
+                         call write_data(fptr, axis_name, axis_data(istart:iend) )
+                    class default
+                         call error_mesg("diag_output_mod::write_axis_meta_data", &
+                              "The file object is not the right type. It must be FmsNetcdfDomainFile_t or "//&
+                                "FmsNetcdfFile_t for a X or Y axis, ", FATAL)
+                  end select
+             endif
+
+          ELSE
+               select type (fptr)
+                    type is (FmsNetcdfDomainFile_t)
+                         call register_axis(fptr, axis_name, lowercase(trim(axis_cart_name)), domain_position=axis_pos )
+                      if (allocated(fptr%pelist)) then
+                         call get_global_io_domain_indices(fptr, trim(axis_name), istart, iend)
+                         call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                      endif
+                    type is (FmsNetcdfUnstructuredDomainFile_t)
+                        call register_axis(fptr, axis_name )
+                    type is (FmsNetcdfFile_t)
+                         call register_axis(fptr, axis_name, dimension_length=size(axis_data))
+                      if (allocated(fptr%pelist)) then
+!                         call get_global_io_domain_indices(fptr, trim(axis_name), istart, iend)
+                         istart = lbound(axis_data,1)
+                         iend = ubound(axis_data,1)
+                         call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                      endif
+                    class default
+                         call error_mesg("diag_output_mod::write_axis_meta_data", &
+                              "The FmsNetcdfDomain file object is not the right type.", FATAL)
+                end select
+                    call register_field(fileob, axis_name, type_str, (/axis_name/) )
+                    call register_variable_attribute(fileob, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                    call register_variable_attribute(fileob, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                    call register_variable_attribute(fileob, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                    select case (axis_direction)
+                         case (1)
+                              call register_variable_attribute(fptr, axis_name, "positive", "up", str_len=len_trim("up"))
+                         case (-1)
+                              call register_variable_attribute(fptr, axis_name, "positive", "down", str_len=len_trim("down"))
+                    end select
+                    call write_data(fileob, axis_name, axis_data(istart:iend) )
+          END IF
+       ELSE
+          IF ( length > 0 ) THEN
+
+            !For an unstructured dimension, only the root rank of the io_domain
+            !pelist will perform the wirte, so a gather of the unstructured
+            !axis size and axis data is required.
+             if (uppercase(trim(axis_cart_name)) .eq. "U") then
+                 if (DomainU .eq. null_domainUG) then
+                     call error_mesg("diag_output_mod::write_axis_meta_data", &
+                                     "A non-nul domainUG is required to" &
+                                     //" write unstructured axis metadata.", &
+                                     FATAL)
+                 endif
+                 io_domain => null()
+                 io_domain => mpp_get_UG_io_domain(DomainU)
+                 io_domain_npes = mpp_get_UG_domain_npes(io_domain)
+                 allocate(io_pelist(io_domain_npes))
+                 call mpp_get_UG_domain_pelist(io_domain, &
+                                               io_pelist)
+                 allocate(unstruct_axis_sizes(io_domain_npes))
+                 unstruct_axis_sizes = 0
+                 call mpp_gather((/size(axis_data)/), &
+                                 unstruct_axis_sizes, &
+                                 io_pelist)
+                 if (mpp_pe() .eq. io_pelist(1)) then
+                     allocate(unstruct_axis_data(sum(unstruct_axis_sizes)))
+                 else
+                     allocate(unstruct_axis_data(1))
+                 endif
+                 unstruct_axis_data = 0.0
+                 call mpp_gather(axis_data, &
+                                 size(axis_data), &
+                                 unstruct_axis_data, &
+                                 unstruct_axis_sizes, &
+                                 io_pelist)
+                  select type (fptr)
+                   type is (FmsNetcdfUnstructuredDomainFile_t)
+                        call register_axis(fptr, axis_name )
+                        call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                        if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                        call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                        if(trim(axis_cart_name).ne."N") call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                        call write_data(fptr, axis_name, axis_data)
+                   class default
+                        call error_mesg("diag_output_mod::write_axis_meta_data", &
+                             "The file unstructred 1 object is not the right type.", NOTE)
+                  end select
+                 deallocate(io_pelist)
+                 deallocate(unstruct_axis_sizes)
+                 deallocate(unstruct_axis_data)
+                 io_domain => null()
+
+             else
+                 select type (fptr)
+                   type is (FmsNetcdfUnstructuredDomainFile_t)
+                        call register_axis(fptr, axis_name, size(axis_data) )
+                        call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                        if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                        call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                        if(trim(axis_cart_name).ne."N") call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                        select case (axis_direction)
+                             case (1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "up", str_len=len_trim("up"))
+                             case (-1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "down", str_len=len_trim("down"))
+                        end select
+                        call write_data(fptr, axis_name, axis_data)
+                   type is (FmsNetcdfDomainFile_t)
+                    if (.not.variable_exists(fptr, axis_name)) then
+                        call register_axis(fptr, axis_name, size(axis_data) )
+                        call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                        if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                        call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                        if(trim(axis_cart_name).ne."N") call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                        select case (axis_direction)
+                             case (1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "up", str_len=len_trim("up"))
+                             case (-1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "down", str_len=len_trim("down"))
+                        end select
+                        call write_data(fptr, axis_name, axis_data)
+                    endif
+                   type is (FmsNetcdfFile_t)
+                    if (.not.variable_exists(fptr, axis_name)) then
+                        call register_axis(fptr, axis_name, size(axis_data) )
+                        call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                        if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                        call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                        if(trim(axis_cart_name).ne."N") call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                        select case (axis_direction)
+                             case (1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "up", str_len=len_trim("up"))
+                             case (-1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "down", str_len=len_trim("down"))
+                        end select
+                        call write_data(fptr, axis_name, axis_data)
+                    endif
+                   class default
+                        call error_mesg("diag_output_mod::write_axis_meta_data", &
+                             "The file object is not the right type.", FATAL)
+                 end select
+             endif
+
+          ELSE
+!> @note Check if the time variable is registered.  It's possible that is_time_axis_registered is set to true if using
+!! time-templated files because they aren't closed when done writing.  An alternative to this set up would be to put
+!! variable_exists into the if statement with an .or. so that it gets registered.
+                is_time_axis_registered = variable_exists(fptr,trim(axis_name),.true.)
+                if (allocated(fptr%pelist) .and. .not. is_time_axis_registered) then
+                 select type (fptr)
+                   type is (FmsNetcdfDomainFile_t)
+                        call register_axis(fptr, trim(axis_name), unlimited )
+                        call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                        if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+
+                        call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                        if(trim(axis_cart_name).ne."N") call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                        is_time_axis_registered = .true.
+                        if (present(time_axis_registered)) time_axis_registered = is_time_axis_registered
+                   type is (FmsNetcdfUnstructuredDomainFile_t)
+                        call register_axis(fptr, axis_name, size(axis_data) )
+                        call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                        if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                        call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                        if(trim(axis_cart_name).ne."N") call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                        is_time_axis_registered = .true.
+                   type is (FmsNetcdfFile_t)
+                        call register_axis(fptr, trim(axis_name), unlimited )
+                        call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                        if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                        call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                        if(trim(axis_cart_name).ne."N") call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                        is_time_axis_registered = .true.
+                        if (present(time_axis_registered)) time_axis_registered = is_time_axis_registered
+                   class default
+                        call error_mesg("diag_output_mod::write_axis_meta_data", &
+                             "The file object is not the right type.", FATAL)
+                 end select
+                endif
+          END IF
+       END IF
+
+       ! Write axis attributes
+       id_axis = mpp_get_id(Axis_types(num_axis_in_file))
+       CALL write_attribute_meta(file_unit, id_axis, num_attributes, attributes, err_msg, varname=axis_name, fileob=fileob)
+       IF ( LEN_TRIM(err_msg) .GT. 0 ) THEN
+          CALL error_mesg('diag_output_mod::write_axis_meta_data', TRIM(err_msg), FATAL)
+       END IF
+
+       !---- write additional attribute (calendar_type) for time axis ----
+       !---- NOTE: calendar attribute is compliant with CF convention
+       !---- http://www.cgd.ucar.edu/cms/eaton/netcdf/CF-current.htm#cal
+       IF ( axis_cart_name == 'T' ) THEN
+          time_axis_flag(num_axis_in_file) = .TRUE.
+          id_time_axis = mpp_get_id(Axis_types(num_axis_in_file))
+          calendar = get_calendar_type()
+
+
+          call register_variable_attribute(fileob, axis_name, "calendar", &
+                                    lowercase(TRIM(valid_calendar_types(calendar))), str_len=len_trim(valid_calendar_types(calendar)) )
+          IF ( time_ops1 ) THEN
+
+             call register_variable_attribute(fileob, axis_name, 'bounds', TRIM(axis_name)//'_bounds', str_len=len_trim(TRIM(axis_name)//'_bounds'))
+          END IF
+          call set_fileobj_time_name(fileob, axis_name)
+       ELSE
+          time_axis_flag(num_axis_in_file) = .FALSE.
+       END IF
+
+       DEALLOCATE(axis_data)
+
+       ! Deallocate attributes
+       IF ( ALLOCATED(attributes) ) THEN
+          DO j=1, num_attributes
+             IF ( allocated(attributes(j)%fatt ) ) THEN
+                DEALLOCATE(attributes(j)%fatt)
+             END IF
+             IF ( allocated(attributes(j)%iatt ) ) THEN
+                DEALLOCATE(attributes(j)%iatt)
+             END IF
+          END DO
+          DEALLOCATE(attributes)
+       END IF
+
+       !------------- write axis containing edge information ---------------
+
+       !  --- this axis has no edges -----
+       IF ( axis_edges <= 0 ) CYCLE
+
+       !  --- was this axis edge previously defined? ---
+       id_axis_current = id_axis
+       axis_name_current = axis_name
+       id_axis = axis_edges
+       edges_index = get_axis_index(id_axis)
+       IF ( edges_index > 0 ) CYCLE
+
+       !  ---- get data for axis edges ----
+       length = get_axis_global_length ( id_axis )
+       ALLOCATE(axis_data(length))
+       CALL get_diag_axis(id_axis, axis_name, axis_units, axis_long_name, axis_cart_name,&
+            & axis_direction, axis_edges, Domain, DomainU, axis_data, num_attributes, attributes)
+
+       !  ---- write edges attribute to original axis ----
+       call register_variable_attribute(fileob, axis_name_current, "edges",trim(axis_name), str_len=len_trim(axis_name))
+       !  ---- add edges index to axis list ----
+       !  ---- assume this is not a time axis ----
+       num_axis_in_file = num_axis_in_file + 1
+       axis_in_file(num_axis_in_file) = id_axis
+       edge_axis_flag(num_axis_in_file) = .TRUE.
+       time_axis_flag (num_axis_in_file) = .FALSE.
+
+       !  ---- write edges axis to file ----
+       IF ( Domain .NE. null_domain1d ) THEN
+          ! assume domain decomposition is irregular and loop through all prev and next
+          ! domain pointers extracting domain extents.  Assume all pes are used in
+          ! decomposition
+          CALL mpp_get_global_domain(Domain, begin=gbegin, END=gend, size=gsize)
+          CALL mpp_get_layout(Domain, ndivs)
+          IF ( ndivs .NE. 1 ) THEN
+             IF ( ALLOCATED(axis_extent) ) DEALLOCATE(axis_extent)
+             ALLOCATE(axis_extent(0:ndivs-1))
+             CALL mpp_get_compute_domains(Domain,size=axis_extent(0:ndivs-1))
+             gend=gend+1
+             axis_extent(ndivs-1)= axis_extent(ndivs-1)+1
+             IF ( ALLOCATED(pelist) ) DEALLOCATE(pelist)
+             ALLOCATE(pelist(0:ndivs-1))
+             CALL mpp_get_pelist(Domain,pelist)
+          END IF
+       END IF
+
+!> Add edges axis with fms2_io
+                 select type (fptr)
+                   type is (FmsNetcdfUnstructuredDomainFile_t)
+                        call register_axis(fptr, axis_name, size(axis_data) )
+                        call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                        if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                        call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                        if(trim(axis_cart_name).ne."N") call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                        select case (axis_direction)
+                             case (1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "up", str_len=len_trim("up"))
+                             case (-1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "down", str_len=len_trim("down"))
+                        end select
+                        call write_data(fptr, axis_name, axis_data)
+                   type is (FmsNetcdfDomainFile_t)
+                    if (.not.variable_exists(fptr, axis_name)) then
+                        call register_axis(fptr, axis_name, size(axis_data) )
+                        call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                        if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                        call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                        if(trim(axis_cart_name).ne."N") call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                        select case (axis_direction)
+                             case (1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "up", str_len=len_trim("up"))
+                             case (-1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "down", str_len=len_trim("down"))
+                        end select
+                        call write_data(fptr, axis_name, axis_data)
+                    endif
+                   type is (FmsNetcdfFile_t)
+                    if (.not.variable_exists(fptr, axis_name)) then
+                        call register_axis(fptr, axis_name, size(axis_data) )
+                        call register_field(fptr, axis_name, type_str, (/axis_name/) )
+                        if(trim(axis_units) .ne. "none") call register_variable_attribute(fptr, axis_name, "units", trim(axis_units), str_len=len_trim(axis_units))
+                        call register_variable_attribute(fptr, axis_name, "long_name", trim(axis_long_name), str_len=len_trim(axis_long_name))
+                        if(trim(axis_cart_name).ne."N") call register_variable_attribute(fptr, axis_name, "axis",trim(axis_cart_name), str_len=len_trim(axis_cart_name))
+                        select case (axis_direction)
+                             case (1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "up", str_len=len_trim("up"))
+                             case (-1)
+                                  call register_variable_attribute(fptr, axis_name, "positive", "down", str_len=len_trim("down"))
+                        end select
+                        call write_data(fptr, axis_name, axis_data)
+                    endif
+                   class default
+                        call error_mesg("diag_output_mod::write_axis_meta_data", &
+                             "The file object unstructured 2 is not the right type.", FATAL)
+                 end select
+       ! Write edge axis attributes
+       id_axis = mpp_get_id(Axis_types(num_axis_in_file))
+!       CALL write_attribute_meta(file_unit, id_axis, num_attributes, attributes, err_msg)
+       IF ( LEN_TRIM(err_msg) .GT. 0 ) THEN
+          CALL error_mesg('diag_output_mod::write_axis_meta_data', TRIM(err_msg), FATAL)
+       END IF
+
+       DEALLOCATE (axis_data)
+       ! Deallocate attributes
+       IF ( ALLOCATED(attributes) ) THEN
+          DO j=1, num_attributes
+             IF ( allocated(attributes(j)%fatt ) ) THEN
+                DEALLOCATE(attributes(j)%fatt)
+             END IF
+             IF ( allocated(attributes(j)%iatt ) ) THEN
+                DEALLOCATE(attributes(j)%iatt)
+             END IF
+          END DO
+          DEALLOCATE(attributes)
+       END IF
+    END DO
+  END SUBROUTINE write_axis_meta_data_fms2_io
+
+  !> @brief Write the field meta data to file.
+  !! @return diag_fieldtype Field
+  !! @details The meta data for the field is written to the file indicated by file_unit
+  FUNCTION write_field_meta_data_fms2_io ( file_unit, name, axes, units, long_name, range, pack, mval,&
+       & avg_name, time_method, standard_name, interp_method, attributes, num_attributes,     &
+       & use_UGdomain, fileob) result ( Field )
+    INTEGER, INTENT(in) :: file_unit !< Output file unit number
+    INTEGER, INTENT(in) :: axes(:) !< Array of axis IDs
+    CHARACTER(len=*), INTENT(in) :: name !< Field name
+    CHARACTER(len=*), INTENT(in) :: units !< Field units
+    CHARACTER(len=*), INTENT(in) :: long_name !< Field's long name
+    REAL, OPTIONAL, INTENT(in) :: RANGE(2) !< Valid range (min, max).  If min > max, the range will be ignored
+    REAL, OPTIONAL, INTENT(in) :: mval !< Missing value, must be within valid range
+    INTEGER, OPTIONAL, INTENT(in) :: pack !< Packing flag.  Only valid when range specified.  Valid values:
+                                          !! Flag | Size
+                                          !! --- | ---
+                                          !! 1 | 64bit
+                                          !! 2 | 32bit
+                                          !! 4 | 16bit
+                                          !! 8 | 8bit
+    CHARACTER(len=*), OPTIONAL, INTENT(in) :: avg_name !< Name of variable containing time averaging info
+    CHARACTER(len=*), OPTIONAL, INTENT(in) :: time_method !< Name of transformation applied to the time-varying data,
+                                                          !! i.e. "avg", "min", "max"
+    CHARACTER(len=*), OPTIONAL, INTENT(in) :: standard_name !< Standard name of field
+    CHARACTER(len=*), OPTIONAL, INTENT(in) :: interp_method
+    TYPE(diag_atttype), DIMENSION(:), allocatable, OPTIONAL, INTENT(in) :: attributes
+    INTEGER, OPTIONAL, INTENT(in) :: num_attributes
+    LOGICAL, OPTIONAL, INTENT(in) :: use_UGdomain
+class(FmsNetcdfFile_t), intent(inout)     :: fileob
+
+    logical :: is_time_bounds !< Flag indicating if the variable is time_bounds
+    CHARACTER(len=256) :: standard_name2
+    CHARACTER(len=1280) :: att_str
+    TYPE(diag_fieldtype) :: Field
+    LOGICAL :: coord_present
+    CHARACTER(len=40) :: aux_axes(SIZE(axes))
+    CHARACTER(len=160) :: coord_att
+    CHARACTER(len=1024) :: err_msg
+
+character(len=128),dimension(size(axes)) :: axis_names
+    REAL :: scale, add
+    INTEGER :: i, indexx, num, ipack, np, att_len
+    LOGICAL :: use_range
+    INTEGER :: axis_indices(SIZE(axes))
+    logical :: use_UGdomain_local
+    !---- Initialize err_msg to bank ----
+    err_msg = ''
+
+    !---- dummy checks ----
+    coord_present = .FALSE.
+    IF( PRESENT(standard_name) ) THEN
+       standard_name2 = standard_name
+    ELSE
+       standard_name2 = 'none'
+    END IF
+
+    use_UGdomain_local = .false.
+    if(present(use_UGdomain)) use_UGdomain_local = use_UGdomain
+
+    num = SIZE(axes(:))
+    ! <ERROR STATUS="FATAL">number of axes < 1</ERROR>
+    IF ( num < 1 ) CALL error_mesg ( 'write_meta_data', 'number of axes < 1', FATAL)
+    ! <ERROR STATUS="FATAL">writing meta data out-of-order to different files</ERROR>
+    IF ( file_unit /= current_file_unit ) CALL error_mesg ( 'write_meta_data',  &
+         & 'writing meta data out-of-order to different files', FATAL)
+
+    IF (trim(name) .eq. "time_bnds" .or. trim(name) .eq. "time_bounds") then
+       is_time_bounds = .true.
+    ELSE
+       is_time_bounds = .false.
+    ENDIF
+
+    !---- check all axes for this field ----
+    !---- set up indexing to axistypes ----
+    DO i = 1, num
+       indexx = get_axis_index(axes(i))
+       !---- point to existing axistype -----
+       IF ( indexx > 0 ) THEN
+          axis_indices(i) = indexx
+       ELSE
+          ! <ERROR STATUS="FATAL">axis data not written for field</ERROR>
+          CALL error_mesg ('write_field_meta_data',&
+               & 'axis data not written for field '//TRIM(name), FATAL)
+       END IF
+       !Get the axes names
+          call get_diag_axis_name(axes(i),axis_names(i))
+    END DO
+
+    !  Create coordinate attribute
+    IF ( num >= 2 .OR. (num==1 .and. use_UGdomain_local) ) THEN
+       coord_att = ' '
+       DO i = 1, num
+          aux_axes(i) = get_axis_aux(axes(i))
+          IF( TRIM(aux_axes(i)) /= 'none' ) THEN
+             IF(LEN_TRIM(coord_att) == 0) THEN
+                coord_att = TRIM(aux_axes(i))
+             ELSE
+                coord_att = TRIM(coord_att)// ' '//TRIM(aux_axes(i))
+             ENDIF
+             coord_present = .TRUE.
+          END IF
+       END DO
+    END IF
+
+    !--------------------- write field meta data ---------------------------
+
+    !---- select packing? ----
+    !(packing option only valid with range option)
+    IF ( PRESENT(pack) ) THEN
+       ipack = pack
+    ELSE
+       ipack = 2
+    END IF
+
+    !---- check range ----
+    use_range = .FALSE.
+    add = 0.0
+    scale = 1.0
+    IF ( PRESENT(range) ) THEN
+       IF ( RANGE(2) > RANGE(1) ) THEN
+          use_range = .TRUE.
+          !---- set packing parameters ----
+          IF ( ipack > 2 ) THEN
+             np = ipack/4
+             add = 0.5*(RANGE(1)+RANGE(2))
+             scale = (RANGE(2)-RANGE(1)) / real(max_range(2,np)-max_range(1,np))
+          END IF
+       END IF
+    END IF
+
+    !---- select packing? ----
+    IF ( PRESENT(mval) ) THEN
+       Field%miss = mval
+       Field%miss_present = .TRUE.
+       IF ( ipack > 2 ) THEN
+          np = ipack/4
+          Field%miss_pack = REAL(missval(np))*scale+add
+          Field%miss_pack_present = .TRUE.
+       ELSE
+          Field%miss_pack = mval
+          Field%miss_pack_present = .FALSE.
+       END IF
+    ELSE
+       Field%miss_present = .FALSE.
+       Field%miss_pack_present = .FALSE.
+    END IF
+
+    !------ write meta data and return fieldtype -------
+!!! Fill in mpp fieldtype for field%field
+    IF ( use_range ) THEN
+       IF ( Field%miss_present ) THEN
+          CALL fillin_fieldtype( Field%Field,&
+               & Axis_types(axis_indices(1:num)),&
+               & name, units, long_name,&
+               & RANGE(1), RANGE(2),&
+               & missing=Field%miss_pack,&
+               & fill=Field%miss_pack,&
+               & scale=scale, add=add, pack=ipack,&
+               & time_method=time_method)
+       ELSE
+          CALL fillin_fieldtype( Field%Field,&
+               & Axis_types(axis_indices(1:num)),&
+               & name, units,  long_name,&
+               & RANGE(1), RANGE(2),&
+               & missing=CMOR_MISSING_VALUE,&
+               & fill=CMOR_MISSING_VALUE,&
+               & scale=scale, add=add, pack=ipack,&
+               & time_method=time_method)
+       END IF
+    ELSE
+       IF ( Field%miss_present ) THEN
+          CALL fillin_fieldtype( Field%Field,&
+               & Axis_types(axis_indices(1:num)),&
+               & name, units, long_name,&
+               & missing=Field%miss_pack,&
+               & fill=Field%miss_pack,&
+               & pack=ipack, time_method=time_method)
+       ELSE
+          CALL fillin_fieldtype( Field%Field,&
+               & Axis_types(axis_indices(1:num)),&
+               & name, units, long_name,&
+               & missing=CMOR_MISSING_VALUE,&
+               & fill=CMOR_MISSING_VALUE,&
+               & pack=ipack, time_method=time_method)
+       END IF
+    END IF
+  if (.not. variable_exists(fileob,name)) then
+  ! ipack Valid values:
+  !        1 = 64bit </LI>
+  !        2 = 32bit </LI>
+  !        4 = 16bit </LI>
+  !        8 =  8bit </LI>
+     select case (ipack)
+     case (1)
+          call register_field(fileob,name,"double",axis_names)
+          !< Don't write the _FillValue, missing_value if the variable is
+          !time_bounds to be cf compliant
+          if (.not. is_time_bounds) then
+          IF ( Field%miss_present ) THEN
+               call register_variable_attribute(fileob,name,"_FillValue",real(Field%miss_pack,8))
+               call register_variable_attribute(fileob,name,"missing_value",real(Field%miss_pack,8))
+          ELSE
+               call register_variable_attribute(fileob,name,"_FillValue",real(CMOR_MISSING_VALUE,8))
+               call register_variable_attribute(fileob,name,"missing_value",real(CMOR_MISSING_VALUE,8))
+          ENDIF
+          IF ( use_range ) then
+               call register_variable_attribute(fileob,name,"valid_range", real(RANGE,8))
+          ENDIF
+          endif !< if (.not. is_time_bounds)
+     case (2) !default
+          call register_field(fileob,name,"float",axis_names)
+          !< Don't write the _FillValue, missing_value if the variable is
+          !time_bounds to be cf compliant
+          if (.not. is_time_bounds) then
+          IF ( Field%miss_present ) THEN
+               call register_variable_attribute(fileob,name,"_FillValue",real(Field%miss_pack,4))
+               call register_variable_attribute(fileob,name,"missing_value",real(Field%miss_pack,4))
+          ELSE
+               call register_variable_attribute(fileob,name,"_FillValue",real(CMOR_MISSING_VALUE,4))
+               call register_variable_attribute(fileob,name,"missing_value",real(CMOR_MISSING_VALUE,4))
+          ENDIF
+          IF ( use_range ) then
+               call register_variable_attribute(fileob,name,"valid_range", real(RANGE,4))
+          ENDIF
+          endif !< if (.not. is_time_bounds)
+     case default
+          CALL error_mesg('diag_output_mod::write_field_meta_data',&
+               &"Pack values must be 1 or 2. Contact the developers.", FATAL)
+     end select
+     if (trim(units) .ne. "none") call register_variable_attribute(fileob,name,"units",trim(units), str_len=len_trim(units))
+     call register_variable_attribute(fileob,name,"long_name",long_name, str_len=len_trim(long_name))
+     IF (present(time_method) ) then
+          call register_variable_attribute(fileob,name,'cell_methods','time: '//trim(time_method), str_len=len_trim('time: '//trim(time_method)))
+     ENDIF
+  endif
+    !---- write user defined attributes -----
+    IF ( PRESENT(num_attributes) ) THEN
+       IF ( PRESENT(attributes) ) THEN
+          IF ( num_attributes .GT. 0 .AND. allocated(attributes) ) THEN
+             CALL write_attribute_meta(file_unit, mpp_get_id(Field%Field), num_attributes, attributes, time_method, err_msg, fileob=fileob, varname=name)
+             IF ( LEN_TRIM(err_msg) .GT. 0 ) THEN
+                CALL error_mesg('diag_output_mod::write_field_meta_data',&
+                     & TRIM(err_msg)//" Contact the developers.", FATAL)
+             END IF
+          ELSE
+             ! Catch some bad cases
+             IF ( num_attributes .GT. 0 .AND. .NOT.allocated(attributes) ) THEN
+                CALL error_mesg('diag_output_mod::write_field_meta_data',&
+                     & 'num_attributes > 0 but attributes is not allocated for attribute '&
+                     &//TRIM(attributes(i)%name)//' for field '//TRIM(name)//'. Contact the developers.', FATAL)
+             ELSE IF ( num_attributes .EQ. 0 .AND. allocated(attributes) ) THEN
+                CALL error_mesg('diag_output_mod::write_field_meta_data',&
+                     & 'num_attributes == 0 but attributes is allocated for attribute '&
+                     &//TRIM(attributes(i)%name)//' for field '//TRIM(name)//'. Contact the developers.', FATAL)
+             END IF
+          END IF
+       ELSE
+          ! More edge error cases
+          CALL error_mesg('diag_output_mod::write_field_meta_data',&
+               & 'num_attributes present but attributes missing for attribute '&
+               &//TRIM(attributes(i)%name)//' for field '//TRIM(name)//'. Contact the developers.', FATAL)
+       END IF
+    ELSE IF ( PRESENT(attributes) ) THEN
+       CALL error_mesg('diag_output_mod::write_field_meta_data',&
+            & 'attributes present but num_attributes missing for attribute '&
+            &//TRIM(attributes(i)%name)//' for field '//TRIM(name)//'. Contact the developers.', FATAL)
+    END IF
+
+    !---- write additional attribute for time averaging -----
+    IF ( PRESENT(avg_name) ) THEN
+       IF ( avg_name(1:1) /= ' ' ) THEN
+          call register_variable_attribute(fileob,name,'time_avg_info',&
+             & trim(avg_name)//'_T1,'//trim(avg_name)//'_T2,'//trim(avg_name)//'_DT', &
+             & str_len=len_trim(trim(avg_name)//'_T1,'//trim(avg_name)//'_T2,'//trim(avg_name)//'_DT'))
+       END IF
+    END IF
+
+    ! write coordinates attribute for CF compliance
+    IF ( coord_present ) then
+         call register_variable_attribute(fileob,name,'coordinates',TRIM(coord_att), str_len=len_trim(coord_att))
+    ENDIF
+    IF ( TRIM(standard_name2) /= 'none' ) then
+         call register_variable_attribute(fileob,name,'standard_name',TRIM(standard_name2), str_len=len_trim(standard_name2))
+    ENDIF
+    !---- write attribute for interp_method ----
+    IF( PRESENT(interp_method) ) THEN
+       call register_variable_attribute(fileob,name,'interp_method', TRIM(interp_method), str_len=len_trim(interp_method))
+    END IF
+
+    !---- get axis domain ----
+    Field%Domain = get_domain2d ( axes )
+    Field%tile_count = get_tile_count ( axes )
+    Field%DomainU = get_domainUG ( axes(1) )
+
+  END FUNCTION write_field_meta_data_fms2_io
+
+  !> \brief Write out attribute meta data to file
+  !!
+  !! Write out the attribute meta data to file, for field and axes
+  SUBROUTINE write_attribute_meta_fms2_io(file_unit, id, num_attributes, attributes, time_method, err_msg, varname, fileob)
+    INTEGER, INTENT(in) :: file_unit !< File unit number
+    INTEGER, INTENT(in) :: id !< ID of field, file, axis to get attribute meta data
+    INTEGER, INTENT(in) :: num_attributes !< Number of attributes to write
+    TYPE(diag_atttype), DIMENSION(:), INTENT(in) :: attributes !< Array of attributes
+    CHARACTER(len=*), INTENT(in), OPTIONAL :: time_method !< To include in cell_methods attribute if present
+    CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg !< Return error message
+    CHARACTER(len=*), INTENT(IN), OPTIONAL :: varname !< The name of the variable
+class(FmsNetcdfFile_t), intent(inout)     :: fileob
+
+    INTEGER :: i, att_len
+    CHARACTER(len=1280) :: att_str
+
+    ! Clear err_msg if present
+    IF ( PRESENT(err_msg) ) err_msg = ''
+
+    DO i = 1, num_attributes
+       SELECT CASE (attributes(i)%type)
+       CASE (NF90_INT)
+          IF ( .NOT.allocated(attributes(i)%iatt) ) THEN
+             IF ( fms_error_handler('diag_output_mod::write_attribute_meta',&
+                  & 'Integer attribute type indicated, but array not allocated for attribute '&
+                  &//TRIM(attributes(i)%name)//'.', err_msg) ) THEN
+                RETURN
+             END IF
+          END IF
+          if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , attributes(i)%iatt)
+       CASE (NF90_FLOAT)
+          IF ( .NOT.allocated(attributes(i)%fatt) ) THEN
+             IF ( fms_error_handler('diag_output_mod::write_attribute_meta',&
+                  & 'Real attribute type indicated, but array not allocated for attribute '&
+                  &//TRIM(attributes(i)%name)//'.', err_msg) ) THEN
+                RETURN
+             END IF
+          END IF
+          if (present(varname))call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , real(attributes(i)%fatt,4) )
+       CASE (NF90_CHAR)
+          att_str = attributes(i)%catt
+          att_len = attributes(i)%len
+          IF ( TRIM(attributes(i)%name).EQ.'cell_methods' .AND. PRESENT(time_method) ) THEN
+             ! Append ",time: time_method" if time_method present
+             att_str = attributes(i)%catt(1:attributes(i)%len)//' time: '//time_method
+             att_len = LEN_TRIM(att_str)
+          END IF
+          if (present(varname))&
+               call register_variable_attribute(fileob, varname,TRIM(attributes(i)%name)  , att_str(1:att_len), str_len=att_len)
+
+       CASE default
+          IF ( fms_error_handler('diag_output_mod::write_attribute_meta', 'Invalid type for attribute '&
+               &//TRIM(attributes(i)%name)//'.', err_msg) ) THEN
+             RETURN
+          END IF
+       END SELECT
+    END DO
+  END SUBROUTINE write_attribute_meta_fms2_io
+
+  !> @brief Writes axis data to file.
+  !! @details Writes axis data to file.  This subroutine is to be called once per file
+  !!     after all <TT>write_meta_data</TT> calls, and before the first
+  !!     <TT>diag_field_out</TT> call.
+  SUBROUTINE done_meta_data(file_unit)
+    INTEGER,  INTENT(in)  :: file_unit !< Output file unit number
+
+    INTEGER               :: i
+
+    !---- write data for all non-time axes ----
+    num_axis_in_file = 0
+  END SUBROUTINE done_meta_data
+
+  !> @brief Outputs the diagnostic data to a file using fms2_io taking a field object as input
+  subroutine diag_field_write_field (field, buffer, static, fileob, file_num, fileobjU, fileobj, fileobjND, fnum_for_domain, time_in)
+    TYPE(diag_fieldtype), INTENT(inout) :: Field !<
+    REAL , INTENT(inout) :: buffer(:,:,:,:)
+    logical, intent(in), optional :: static
+    class(FmsNetcdfFile_t), optional, intent(inout),target :: fileob
+    class(FmsNetcdfFile_t), pointer :: fptr => null()
+    integer, intent(in), optional  :: file_num
+    type(FmsNetcdfUnstructuredDomainFile_t),intent(inout), optional :: fileobjU(:)
+    type(FmsNetcdfDomainFile_t),intent(inout), optional:: fileobj(:)
+    type(FmsNetcdfFile_t),intent(inout), optional:: fileobjND(:)
+    character(len=2), intent(in), optional :: fnum_for_domain
+    INTEGER, OPTIONAL, INTENT(in) :: time_in
+    integer :: time
+    real(kind=4),allocatable :: local_buffer(:,:,:,:)
+     if (present(static)) then
+          if (static) time = 0
+     elseif (present(time_in)) then
+          time = time_in
+     else
+          time = 0
+     endif
+
+     if (present(fileob)) then !> Write output to the fileob file
+          fptr => fileob
+          select type (fptr)
+          type is (FmsNetcdfFile_t)
+               call write_data (fptr,trim(mpp_get_field_name(field%field)),buffer)
+          type is (FmsNetcdfDomainFile_t)
+               call write_data (fptr,trim(mpp_get_field_name(field%field)),buffer)
+          type is (FmsNetcdfUnstructuredDomainFile_t)
+               call write_data (fptr,trim(mpp_get_field_name(field%field)),buffer)
+          class default
+               call error_mesg("diag_field_write","fileob passed in is not one of the FmsNetcdfFile_t types",fatal)
+          end select
+     elseif (present(file_num) .and. present(fileobjU) .and. present(fileobjND) .and. present(fileobj) .and. present(fnum_for_domain)) then
+          allocate(local_buffer(size(buffer,1),size(buffer,2),size(buffer,3),size(buffer,4)))
+          local_buffer = real(buffer,4)
+     !> Figure out which file object to write output to
+!          if (fnum_for_domain == "2d" .or. fnum_for_domain == "nd") then
+          if (fnum_for_domain == "2d" ) then
+               if (check_if_open(fileobj(file_num))) then
+                    if (time == 0) then
+                         call write_data (fileobj (file_num), trim(mpp_get_field_name(field%field)), local_buffer)
+                    else
+                         call write_data (fileobj (file_num), trim(mpp_get_field_name(field%field)), local_buffer, unlim_dim_level=time)
+                    endif
+               endif
+          elseif (fnum_for_domain == "nd") then
+               if (check_if_open(fileobjND (file_num)) ) then
+                    if (time == 0) then
+                         call write_data (fileobjND (file_num), trim(mpp_get_field_name(field%field)), local_buffer)
+                    else
+                         call write_data (fileobjND (file_num), trim(mpp_get_field_name(field%field)), local_buffer, unlim_dim_level=time)
+                    endif
+               endif
+          elseif (fnum_for_domain == "ug") then
+                    if (time == 0) then
+                         call write_data (fileobjU(file_num), trim(mpp_get_field_name(field%field)), local_buffer)
+                    else
+                         call write_data (fileobjU(file_num), trim(mpp_get_field_name(field%field)), local_buffer, unlim_dim_level=time)
+                    endif
+          else
+               call error_mesg("diag_field_write","No file object is associated with this file number",fatal)
+          endif
+     elseif (present(file_num) ) then
+          write (6,*) present(file_num) ,present(fileobjU) , present(fileobjND) , present(fileobj) , present(fnum_for_domain)
+          call error_mesg("diag_field_write","When FILE_NUM is used to determine which file object to use,"&
+           //" You must also include fileobjU, fileobj, fileonjND, and fnum_for_domain",fatal)
+     else
+          call error_mesg("diag_field_write","You must include a fileob or a file_num.",fatal)
+     endif
+     if (allocated(local_buffer)) deallocate(local_buffer)
+  end subroutine diag_field_write_field
+
+  !> \brief Writes diagnostic data out using fms2_io routine.
+  subroutine diag_field_write_varname (varname, buffer, static, fileob, file_num, fileobjU, fileobj, fileobjND, fnum_for_domain, time_in)
+    CHARACTER(len=*), INTENT(in) :: varname !<
+    REAL , INTENT(inout) :: buffer(:,:,:,:)
+    logical, intent(in), optional :: static
+    class(FmsNetcdfFile_t), intent(inout), optional, target :: fileob
+    class(FmsNetcdfFile_t), pointer :: fptr => null()
+    integer, intent(in), optional  :: file_num
+    type(FmsNetcdfUnstructuredDomainFile_t),intent(inout), optional :: fileobjU(:)
+    type(FmsNetcdfDomainFile_t),intent(inout), optional:: fileobj(:)
+    type(FmsNetcdfFile_t),intent(inout), optional:: fileobjND(:)
+    character(len=2), intent(in), optional :: fnum_for_domain
+    INTEGER, OPTIONAL, INTENT(in) :: time_in
+    integer :: time
+    real(kind=4),allocatable :: local_buffer(:,:,:,:)
+!> Set up the time.  Static field and default time is 0
+     if (present(static) .and. static) then
+          time = 0
+     elseif (present(time_in)) then
+          time = time_in
+     else
+          time = 0
+     endif
+
+     if (present(fileob)) then !> Write output to the fileob file
+          fptr => fileob
+          select type (fptr)
+          type is (FmsNetcdfFile_t)
+               call write_data (fptr,trim(varname),buffer)
+          type is (FmsNetcdfDomainFile_t)
+               call write_data (fptr,trim(varname),buffer)
+          type is (FmsNetcdfUnstructuredDomainFile_t)
+               call write_data (fptr,trim(varname),buffer)
+          class default
+               call error_mesg("diag_field_write","fileob passed in is not one of the FmsNetcdfFile_t types",fatal)
+          end select
+          call write_data (fileob,trim(varname),buffer)
+     elseif (present(file_num) .and. present(fileobjU) .and. present(fileobj) .and. present(fileobjND) .and. present(fnum_for_domain)) then
+     !> Figure out which file object to write output to
+          if (fnum_for_domain == "2d" ) then
+               if (check_if_open(fileobj(file_num))) then
+                    call write_data (fileobj (file_num), trim(varname), buffer, unlim_dim_level=time )
+               endif
+          elseif (fnum_for_domain == "nd") then
+               if (check_if_open(fileobjND (file_num)) ) then
+                    call write_data (fileobjND (file_num), trim(varname), buffer, unlim_dim_level=time)
+               endif
+          elseif (fnum_for_domain == "ug") then
+               call write_data (fileobjU(file_num), trim(varname), buffer, unlim_dim_level=time)
+          else
+               call error_mesg("diag_field_write","No file object is associated with this file number",fatal)
+          endif
+     elseif (present(file_num) ) then
+          call error_mesg("diag_field_write","When FILE_NUM is used to determine which file object to use,"&
+           //" You must also include fileobjU, fileobj, and fnum_for_domain",fatal)
+     else
+          call error_mesg("diag_field_write","You must include a fileob or a file_num.",fatal)
+     endif
+  end subroutine diag_field_write_varname
+!> \brief Writes the time data to the history file
+  subroutine diag_write_time (fileob,rtime_value,time_index,time_name)
+     class(FmsNetcdfFile_t), intent(inout),target  :: fileob      !< fms2_io file object
+     class(FmsNetcdfFile_t), pointer                        :: fptr => null()
+     real, intent(in)                                       :: rtime_value !< The value of time to be written
+     integer, intent(in)                                    :: time_index  !< The index of the time variable
+     character(len=*),intent(in),optional                   :: time_name   !< The name of the time variable
+     character(len=:),allocatable                           :: name_time   !< The name of the time variable
+!> Get the name of the time variable
+     if (present(time_name)) then
+          allocate(character(len=len(time_name)) :: name_time)
+          name_time = time_name
+     else
+          allocate(character(len=4) :: name_time)
+          name_time = "time"
+     endif
+!> Write the time data
+     call write_data (fileob, trim(name_time), rtime_value, unlim_dim_level=time_index)
+!> Cleanup
+     if (allocated(name_time)) deallocate(name_time)
+     if (associated(fptr)) nullify(fptr)
+  end subroutine diag_write_time
+
+  !> @brief Return the axis index number.
+  !! @return Integer index
+  FUNCTION get_axis_index(num) RESULT ( index )
+    INTEGER, INTENT(in) :: num
+
+    INTEGER :: index
+    INTEGER :: i
+
+    !---- get the array index for this axis type ----
+    !---- set up pointers to axistypes ----
+    !---- write axis meta data for new axes ----
+    index = 0
+    DO i = 1, num_axis_in_file
+       IF ( num == axis_in_file(i) ) THEN
+          index = i
+          EXIT
+       END IF
+    END DO
+  END FUNCTION get_axis_index
+
+  !> @brief Return the global attribute type.
+  SUBROUTINE get_diag_global_att(gAtt)
+    TYPE(diag_global_att_type), INTENT(out) :: gAtt
+
+    gAtt=diag_global_att
+  END SUBROUTINE get_diag_global_att
+
+  !> @brief Set the global attribute type.
+  SUBROUTINE set_diag_global_att(component, gridType, tileName)
+    CHARACTER(len=*),INTENT(in) :: component, gridType, tileName
+
+    ! The following two lines are set to remove compile time warnings
+    ! about 'only used once'.
+    CHARACTER(len=64) :: component_tmp
+    component_tmp = component
+    ! Don't know how to set these for specific component
+    ! Want to be able to say
+    ! if(output_file has component) then
+    diag_global_att%grid_type = gridType
+    diag_global_att%tile_name = tileName
+    ! endif
+  END SUBROUTINE set_diag_global_att
+END MODULE diag_output_mod
+!> @}
+! close documentation grouping

--- a/src_override/diag_util.F90
+++ b/src_override/diag_util.F90
@@ -1,0 +1,2660 @@
+!***********************************************************************
+!*                   GNU Lesser General Public License
+!*
+!* This file is part of the GFDL Flexible Modeling System (FMS).
+!*
+!* FMS is free software: you can redistribute it and/or modify it under
+!* the terms of the GNU Lesser General Public License as published by
+!* the Free Software Foundation, either version 3 of the License, or (at
+!* your option) any later version.
+!*
+!* FMS is distributed in the hope that it will be useful, but WITHOUT
+!* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+!* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+!* for more details.
+!*
+!* You should have received a copy of the GNU Lesser General Public
+!* License along with FMS.  If not, see <http://www.gnu.org/licenses/>.
+!***********************************************************************
+!> @defgroup diag_util_mod diag_util_mod
+!> @ingroup diag_manager
+!! @brief Functions and subroutines necessary for the <TT>diag_manager_mod</TT>.
+!! @author Seth Underwood
+
+!> @file
+!> @brief File for @ref diag_util_mod
+
+MODULE diag_util_mod
+
+use platform_mod
+use,intrinsic :: iso_fortran_env, only: real128
+use,intrinsic :: iso_c_binding, only: c_double,c_float,c_int64_t, &
+                                      c_int32_t,c_int16_t,c_intptr_t
+
+  !   <FUTURE>
+  !     Make an interface <TT>check_bounds_are_exact</TT> for the subroutines <TT>check_bounds_are_exact_static</TT> and
+  !     <TT>check_bounds_are_exact_dynamic</TT>.
+  !     <PRE>
+  !       INTERFACE check_bounds_are_exact
+  !         MODULE PROCEDURE check_bounds_are_exact_static
+  !         MODULE PROCEDURE check_bounds_are_exact_dynamic
+  !       END INTERFACE check_bounds_are_exact
+  !     </PRE>
+  !   </FUTURE>
+
+  USE diag_data_mod, ONLY: output_fields, input_fields, files, do_diag_field_log, diag_log_unit,&
+       & VERY_LARGE_AXIS_LENGTH, time_zero, VERY_LARGE_FILE_FREQ, END_OF_RUN, EVERY_TIME,&
+       & DIAG_SECONDS, DIAG_MINUTES, DIAG_HOURS, DIAG_DAYS, DIAG_MONTHS, DIAG_YEARS, base_time,&
+       & time_unit_list, max_files, base_year, base_month, base_day, base_hour, base_minute,&
+       & base_second, num_files, max_files, max_fields_per_file, max_out_per_in_field,&
+       & max_input_fields,num_input_fields, max_output_fields, num_output_fields, coord_type,&
+       & mix_snapshot_average_fields, global_descriptor, CMOR_MISSING_VALUE, use_cmor, pack_size,&
+       & debug_diag_manager, flush_nc_files, output_field_type, max_field_attributes, max_file_attributes,&
+       & file_type, prepend_date, region_out_use_alt_value, GLO_REG_VAL, GLO_REG_VAL_ALT,&
+       & DIAG_FIELD_NOT_FOUND, diag_init_time, diag_atttype
+  USE diag_data_mod, ONLY: fileobjU, fileobj, fnum_for_domain, fileobjND
+  USE diag_axis_mod, ONLY: get_diag_axis_data, get_axis_global_length, get_diag_axis_cart,&
+       & get_domain1d, get_domain2d, diag_subaxes_init, diag_axis_init, get_diag_axis, get_axis_aux,&
+       & get_axes_shift, get_diag_axis_name, get_diag_axis_domain_name, get_domainUG, &
+       & get_axis_reqfld, axis_is_compressed, get_compressed_axes_ids
+  USE diag_output_mod, ONLY: diag_output_init, write_axis_meta_data,&
+       & write_field_meta_data, done_meta_data
+  USE diag_output_mod, ONLY: diag_field_write, diag_write_time !<fms2_io use_mpp_io=.false.
+  USE diag_grid_mod, ONLY: get_local_indexes
+  USE fms_mod, ONLY: error_mesg, FATAL, WARNING, NOTE, mpp_pe, mpp_root_pe, lowercase, fms_error_handler,&
+       & write_version_number, do_cf_compliance
+  USE fms_io_mod, ONLY: get_tile_string, return_domain, string
+  USE fms2_io_mod, ONLY: fms2_io_get_instance_filename => get_instance_filename
+  USE fms_io_mod, ONLY: mpp_io_get_instance_filename => get_instance_filename
+  USE mpp_domains_mod,ONLY: domain1d, domain2d, mpp_get_compute_domain, null_domain1d, null_domain2d,&
+       & OPERATOR(.NE.), OPERATOR(.EQ.), mpp_modify_domain, mpp_get_domain_components,&
+       & mpp_get_ntile_count, mpp_get_current_ntile, mpp_get_tile_id, mpp_mosaic_defined, mpp_get_tile_npes,&
+       & domainUG, null_domainUG
+  USE time_manager_mod,ONLY: time_type, OPERATOR(==), OPERATOR(>), NO_CALENDAR, increment_date,&
+       & increment_time, get_calendar_type, valid_calendar_types, get_date, get_time, leap_year,&
+       & OPERATOR(-), OPERATOR(<), OPERATOR(>=), OPERATOR(<=), OPERATOR(==)
+  USE time_manager_mod, ONLY: get_calendar_type
+  USE mpp_io_mod, ONLY: mpp_close
+  USE mpp_mod, ONLY: mpp_npes
+  USE fms_io_mod, ONLY: get_mosaic_tile_file_ug
+  USE constants_mod, ONLY: SECONDS_PER_DAY, SECONDS_PER_HOUR, SECONDS_PER_MINUTE
+use fms2_io_mod
+#ifdef use_netCDF
+  USE netcdf, ONLY: NF90_CHAR
+#endif
+
+  IMPLICIT NONE
+  PRIVATE
+  PUBLIC get_subfield_size, log_diag_field_info, update_bounds, check_out_of_bounds,&
+       & check_bounds_are_exact_dynamic, check_bounds_are_exact_static, init_file, diag_time_inc,&
+       & find_input_field, init_input_field, init_output_field, diag_data_out, write_static,&
+       & check_duplicate_output_fields, get_date_dif, get_subfield_vert_size, sync_file_times,&
+       & prepend_attribute, attribute_init, diag_util_init
+
+
+  !> @brief Prepend a value to a string attribute in the output field or output file.
+  !> @ingroup diag_util_mod
+  INTERFACE prepend_attribute
+     MODULE PROCEDURE prepend_attribute_field
+     MODULE PROCEDURE prepend_attribute_file
+  END INTERFACE prepend_attribute
+
+  !> @brief Allocates the atttype in out_file.
+  !> @ingroup diag_util_mod
+  INTERFACE attribute_init
+     MODULE PROCEDURE attribute_init_field
+     MODULE PROCEDURE attribute_init_file
+  END INTERFACE attribute_init
+
+!> @addtogroup diag_util_mod
+!> @{
+
+  ! Include variable "version" to be written to log file.
+#include <file_version.h>
+
+  LOGICAL :: module_initialized = .FALSE.
+
+
+CONTAINS
+
+  !> @brief Write the version number of this file to the log file.
+  SUBROUTINE diag_util_init()
+    IF (module_initialized) THEN
+       RETURN
+    END IF
+
+    ! Write version number out to log file
+    call write_version_number("DIAG_UTIL_MOD", version)
+  END SUBROUTINE diag_util_init
+
+  !> @brief Get the size, start, and end indices for output fields.
+  SUBROUTINE get_subfield_size(axes, outnum)
+    INTEGER, INTENT(in) :: axes(:) !< axes of the input_field
+    INTEGER, INTENT(in) :: outnum  !< position in array output_fields
+
+    REAL, ALLOCATABLE   :: global_lat(:), global_lon(:), global_depth(:)
+    INTEGER :: global_axis_size, global_axis_sizey
+    INTEGER :: i,xbegin,xend,ybegin,yend,xbegin_l,xend_l,ybegin_l,yend_l
+    CHARACTER(len=1) :: cart
+    TYPE(domain2d) :: Domain2, Domain2_new
+    TYPE(domain1d) :: Domain1, Domain1x, Domain1y
+    REAL :: start(3) !< start coordinates in 3 axes
+    REAL :: end(3) !< end coordinates in 3 axes
+    INTEGER :: gstart_indx(3)!< global start indices of output domain in 3 axes
+    INTEGER :: gend_indx(3) !< global end indices of output domain in 3 axes
+    REAL, ALLOCATABLE :: subaxis_x(:) !< containing local coordinates in x,y,z axes
+    REAL, ALLOCATABLE :: subaxis_y(:) !< containing local coordinates in x,y,z axes
+    REAL, ALLOCATABLE :: subaxis_z(:) !< containing local coordinates in x,y,z axes
+    CHARACTER(len=128) :: msg
+    INTEGER :: ishift, jshift
+    INTEGER :: grv !< Value used to determine if the region defined in the diag_table is for the whole axis, or a sub-axis
+    CHARACTER(len=128), DIMENSION(2) :: axis_domain_name
+
+    !initilization for local output
+    ! initially out of (lat/lon/depth) range
+    start = -1.e10
+    end = -1.e10
+    gstart_indx = -1
+    gend_indx = -1
+
+    ! get the value to compare to determine if writing full axis data
+    IF ( region_out_use_alt_value ) THEN
+       grv = GLO_REG_VAL_ALT
+    ELSE
+       grv = GLO_REG_VAL
+    END IF
+
+    ! get axis data (lat, lon, depth) and indices
+    start = output_fields(outnum)%output_grid%start
+    end = output_fields(outnum)%output_grid%end
+
+    CALL get_diag_axis_domain_name(axes(1), axis_domain_name(1))
+    CALL get_diag_axis_domain_name(axes(2), axis_domain_name(2))
+
+    IF (   INDEX(lowercase(axis_domain_name(1)), 'cubed') == 0 .AND. &
+         & INDEX(lowercase(axis_domain_name(2)), 'cubed') == 0 ) THEN
+       DO i = 1, SIZE(axes(:))
+          global_axis_size = get_axis_global_length(axes(i))
+          output_fields(outnum)%output_grid%subaxes(i) = -1
+          CALL get_diag_axis_cart(axes(i), cart)
+          SELECT CASE(cart)
+          CASE ('X')
+             ! <ERROR STATUS="FATAL">wrong order of axes.  X should come first.</ERROR>
+             IF( i.NE.1 ) CALL error_mesg('diag_util_mod::get_subfield_size',&
+                  & 'wrong order of axes, X should come first',FATAL)
+             ALLOCATE(global_lon(global_axis_size))
+             CALL get_diag_axis_data(axes(i),global_lon)
+             IF( INT(start(i)) == grv .AND. INT(end(i)) == grv ) THEN
+                gstart_indx(i) = 1
+                gend_indx(i) = global_axis_size
+                output_fields(outnum)%output_grid%subaxes(i) = axes(i)
+             ELSE
+                gstart_indx(i) = get_index(start(i),global_lon)
+                gend_indx(i) = get_index(END(i),global_lon)
+             END IF
+             ALLOCATE(subaxis_x(gstart_indx(i):gend_indx(i)))
+             subaxis_x=global_lon(gstart_indx(i):gend_indx(i))
+          CASE ('Y')
+             ! <ERROR STATUS="FATAL">wrong order of axes, Y should come second.</ERROR>
+             IF( i.NE.2 ) CALL error_mesg('diag_util_mod::get_subfield_size',&
+                  & 'wrong order of axes, Y should come second',FATAL)
+             ALLOCATE(global_lat(global_axis_size))
+             CALL get_diag_axis_data(axes(i),global_lat)
+             IF( INT(start(i)) == grv .AND. INT(END(i)) == grv ) THEN
+                gstart_indx(i) = 1
+                gend_indx(i) = global_axis_size
+                output_fields(outnum)%output_grid%subaxes(i) = axes(i)
+             ELSE
+                gstart_indx(i) = get_index(start(i),global_lat)
+                gend_indx(i) = get_index(END(i),global_lat)
+             END IF
+             ALLOCATE(subaxis_y(gstart_indx(i):gend_indx(i)))
+             subaxis_y=global_lat(gstart_indx(i):gend_indx(i))
+          CASE ('Z')
+             ! <ERROR STATUS="FATAL">wrong values in vertical axis of region</ERROR>
+             IF ( start(i)*END(i)<0. ) CALL error_mesg('diag_util_mod::get_subfield_size',&
+                  & 'wrong values in vertical axis of region',FATAL)
+             IF ( start(i)>=0. .AND. END(i)>0. ) THEN
+                ALLOCATE(global_depth(global_axis_size))
+                CALL get_diag_axis_data(axes(i),global_depth)
+                gstart_indx(i) = get_index(start(i),global_depth)
+                gend_indx(i) = get_index(END(i),global_depth)
+                ALLOCATE(subaxis_z(gstart_indx(i):gend_indx(i)))
+                subaxis_z=global_depth(gstart_indx(i):gend_indx(i))
+                output_fields(outnum)%output_grid%subaxes(i) =&
+                     & diag_subaxes_init(axes(i),subaxis_z, gstart_indx(i),gend_indx(i))
+                DEALLOCATE(subaxis_z,global_depth)
+             ELSE ! regional vertical axis is the same as global vertical axis
+                gstart_indx(i) = 1
+                gend_indx(i) = global_axis_size
+                output_fields(outnum)%output_grid%subaxes(i) = axes(i)
+                ! <ERROR STATUS="FATAL">i should equal 3 for z axis</ERROR>
+                IF( i /= 3 ) CALL error_mesg('diag_util_mod::get_subfield_size',&
+                     & 'i should equal 3 for z axis', FATAL)
+             END IF
+          CASE default
+             ! <ERROR STATUS="FATAL">Wrong axis_cart</ERROR>
+             CALL error_mesg('diag_util_mod::get_subfield_size', 'Wrong axis_cart', FATAL)
+          END SELECT
+       END DO
+
+       DO i = 1, SIZE(axes(:))
+          IF ( gstart_indx(i) == -1 .OR. gend_indx(i) == -1 ) THEN
+             ! <ERROR STATUS="FATAL">
+             !   can not find gstart_indx/gend_indx for <output_fields(outnum)%output_name>,
+             !   check region bounds for axis <i>.
+             ! </ERROR>
+             WRITE(msg,'(A,I2)') ' check region bounds for axis ', i
+             CALL error_mesg('diag_util_mod::get_subfield_size', 'can not find gstart_indx/gend_indx for '&
+                  & //TRIM(output_fields(outnum)%output_name)//','//TRIM(msg), FATAL)
+          END IF
+       END DO
+    ELSE ! cubed sphere
+       ! get the i and j start and end indexes
+       CALL get_local_indexes(LONSTART=start(1), LONEND=END(1), &
+            &                 LATSTART=start(2), LATEND=END(2), &
+            &                 ISTART=gstart_indx(1), IEND=gend_indx(1), &
+            &                 JSTART=gstart_indx(2), JEND=gend_indx(2))
+       global_axis_size =  get_axis_global_length(axes(1))
+       ALLOCATE(global_lon(global_axis_size))
+       global_axis_sizey = get_axis_global_length(axes(2))
+       ALLOCATE(global_lat(global_axis_sizey))
+       CALL get_diag_axis_data(axes(1),global_lon)
+       CALL get_diag_axis_data(axes(2),global_lat)
+
+       !Potential fix for out-of-bounds error for global_lon and global_lat.
+       IF ((gstart_indx(1) .GT. 0 .AND. gstart_indx(2) .GT. 0) .AND. &
+           (gstart_indx(1) .LE. global_axis_size .AND. gstart_indx(2) .LE. global_axis_sizey) .AND. &
+           (gend_indx(1) .GT. 0 .AND. gend_indx(2) .GT. 0) .AND. &
+           (gend_indx(1) .LE. global_axis_size .AND. gend_indx(2) .LE. global_axis_sizey)) THEN
+          ALLOCATE(subaxis_x(gstart_indx(1):gend_indx(1)))
+          ALLOCATE(subaxis_y(gstart_indx(2):gend_indx(2)))
+          subaxis_x=global_lon(gstart_indx(1):gend_indx(1))
+          subaxis_y=global_lat(gstart_indx(2):gend_indx(2))
+       END IF
+
+       ! Now deal with the Z component
+       IF ( SIZE(axes(:)) > 2 ) THEN
+          global_axis_size = get_axis_global_length(axes(3))
+          output_fields(outnum)%output_grid%subaxes(3) = -1
+          CALL get_diag_axis_cart(axes(3), cart)
+          ! <ERROR STATUS="FATAL">
+          !   axis(3) should be Z-axis
+          ! </ERROR>
+          IF ( lowercase(cart) /= 'z' ) CALL error_mesg('diag_util_mod::get_subfield_size', &
+               &'axis(3) should be Z-axis', FATAL)
+          ! <ERROR STATUS="FATAL">
+          !   wrong values in vertical axis of region
+          ! </ERROR>
+          IF ( start(3)*END(3)<0. ) CALL error_mesg('diag_util_mod::get_subfield_size',&
+               & 'wrong values in vertical axis of region',FATAL)
+          IF ( start(3)>=0. .AND. END(3)>0. ) THEN
+             ALLOCATE(global_depth(global_axis_size))
+             CALL get_diag_axis_data(axes(3),global_depth)
+             gstart_indx(3) = get_index(start(3),global_depth)
+             IF( start(3) == 0.0 )  gstart_indx(3) = 1
+             gend_indx(3) = get_index(END(3),global_depth)
+             IF( start(3) >= MAXVAL(global_depth) ) gstart_indx(3)= global_axis_size
+             IF( END(3)   >= MAXVAL(global_depth) ) gend_indx(3)  = global_axis_size
+
+             ALLOCATE(subaxis_z(gstart_indx(3):gend_indx(3)))
+             subaxis_z=global_depth(gstart_indx(3):gend_indx(3))
+             output_fields(outnum)%output_grid%subaxes(3) =&
+                  & diag_subaxes_init(axes(3),subaxis_z, gstart_indx(3),gend_indx(3))
+             DEALLOCATE(subaxis_z,global_depth)
+          ELSE ! regional vertical axis is the same as global vertical axis
+             gstart_indx(3) = 1
+             gend_indx(3) = global_axis_size
+             output_fields(outnum)%output_grid%subaxes(3) = axes(3)
+          END IF
+       END IF
+    END IF
+
+    ! get domain and compute_domain(xbegin,xend,ybegin,yend)
+    xbegin = -1
+    xend = -1
+    ybegin = -1
+    yend = -1
+
+    Domain2 = get_domain2d(axes)
+    IF ( Domain2 .NE. NULL_DOMAIN2D ) THEN
+       CALL mpp_get_compute_domain(Domain2, xbegin, xend, ybegin, yend)
+       CALL mpp_get_domain_components(Domain2, Domain1x, Domain1y)
+    ELSE
+       DO i = 1, MIN(SIZE(axes(:)),2)
+          Domain1 = get_domain1d(axes(i))
+          IF ( Domain1 .NE. NULL_DOMAIN1D ) THEN
+             CALL get_diag_axis_cart(axes(i),cart)
+             SELECT CASE(cart)
+             CASE ('X')
+                Domain1x = get_domain1d(axes(i))
+                CALL mpp_get_compute_domain(Domain1x, xbegin, xend)
+             CASE ('Y')
+                Domain1y = get_domain1d(axes(i))
+                CALL mpp_get_compute_domain(Domain1y, ybegin, yend)
+             CASE default ! do nothing here
+             END SELECT
+          ELSE
+             ! <ERROR STATUS="FATAL">No domain available</ERROR>
+             CALL error_mesg('diag_util_mod::get_subfield_size', 'NO domain available', FATAL)
+          END IF
+       END DO
+    END IF
+
+    CALL get_axes_shift(axes, ishift, jshift)
+    xend = xend+ishift
+    yend = yend+jshift
+
+    IF ( xbegin == -1 .OR. xend == -1 .OR. ybegin == -1 .OR. yend == -1 ) THEN
+       ! <ERROR STATUS="FATAL">wrong compute domain indices</ERROR>
+       CALL error_mesg('diag_util_mod::get_subfield_size', 'wrong compute domain indices',FATAL)
+    END IF
+
+    ! get the area containing BOTH compute domain AND local output area
+    IF( gstart_indx(1) > xend .OR. xbegin > gend_indx(1) ) THEN
+       output_fields(outnum)%output_grid%l_start_indx(1) = -1
+       output_fields(outnum)%output_grid%l_end_indx(1) = -1
+       output_fields(outnum)%need_compute = .FALSE. ! not involved
+    ELSEIF ( gstart_indx(2) > yend .OR. ybegin > gend_indx(2) ) THEN
+       output_fields(outnum)%output_grid%l_start_indx(2) = -1
+       output_fields(outnum)%output_grid%l_end_indx(2) = -1
+       output_fields(outnum)%need_compute = .FALSE. ! not involved
+    ELSE
+       output_fields(outnum)%output_grid%l_start_indx(1) = MAX(xbegin, gstart_indx(1))
+       output_fields(outnum)%output_grid%l_start_indx(2) = MAX(ybegin, gstart_indx(2))
+       output_fields(outnum)%output_grid%l_end_indx(1) = MIN(xend, gend_indx(1))
+       output_fields(outnum)%output_grid%l_end_indx(2) = MIN(yend, gend_indx(2))
+       output_fields(outnum)%need_compute = .TRUE.  ! involved in local output
+    END IF
+
+    IF ( output_fields(outnum)%need_compute ) THEN
+       ! need to modify domain1d and domain2d for subaxes
+       xbegin_l = output_fields(outnum)%output_grid%l_start_indx(1)
+       xend_l = output_fields(outnum)%output_grid%l_end_indx(1)
+       ybegin_l = output_fields(outnum)%output_grid%l_start_indx(2)
+       yend_l = output_fields(outnum)%output_grid%l_end_indx(2)
+       CALL mpp_modify_domain(Domain2, Domain2_new, xbegin_l,xend_l, ybegin_l,yend_l,&
+            & gstart_indx(1),gend_indx(1), gstart_indx(2),gend_indx(2))
+
+       output_fields(outnum)%output_grid%subaxes(1) =&
+            & diag_subaxes_init(axes(1),subaxis_x, gstart_indx(1),gend_indx(1),Domain2_new)
+       output_fields(outnum)%output_grid%subaxes(2) =&
+            & diag_subaxes_init(axes(2),subaxis_y, gstart_indx(2),gend_indx(2),Domain2_new)
+       DO i = 1, SIZE(axes(:))
+          IF ( output_fields(outnum)%output_grid%subaxes(i) == -1 ) THEN
+             ! <ERROR STATUS="FATAL">
+             !   <output_fields(outnum)%output_name> error at i = <i>
+             ! </ERROR>
+             WRITE(msg,'(a,"/",I4)') 'at i = ',i
+             CALL error_mesg('diag_util_mod::get_subfield_size '//TRIM(output_fields(outnum)%output_name),&
+                  'error '//TRIM(msg), FATAL)
+          END IF
+       END DO
+
+       ! local start index should start from 1
+       output_fields(outnum)%output_grid%l_start_indx(1) = MAX(xbegin, gstart_indx(1)) - xbegin + 1
+       output_fields(outnum)%output_grid%l_start_indx(2) = MAX(ybegin, gstart_indx(2)) - ybegin + 1
+       output_fields(outnum)%output_grid%l_end_indx(1) = MIN(xend, gend_indx(1)) - xbegin + 1
+       output_fields(outnum)%output_grid%l_end_indx(2) = MIN(yend, gend_indx(2)) - ybegin + 1
+       IF ( SIZE(axes(:))>2 ) THEN
+          output_fields(outnum)%output_grid%l_start_indx(3) = gstart_indx(3)
+          output_fields(outnum)%output_grid%l_end_indx(3) = gend_indx(3)
+       ELSE
+          output_fields(outnum)%output_grid%l_start_indx(3) = 1
+          output_fields(outnum)%output_grid%l_end_indx(3) = 1
+       END IF
+    END IF
+    IF ( ALLOCATED(subaxis_x) ) DEALLOCATE(subaxis_x, global_lon)
+    IF ( ALLOCATED(subaxis_y) ) DEALLOCATE(subaxis_y, global_lat)
+  END SUBROUTINE get_subfield_size
+
+  !> @brief Get size, start and end indices for output fields.
+  SUBROUTINE get_subfield_vert_size(axes, outnum)
+    INTEGER, DIMENSION(:), INTENT(in) :: axes !< axes of the input_field
+    INTEGER, INTENT(in) :: outnum  !< position in array output_fields
+
+    REAL, DIMENSION(3) :: start !< start and end coordinates in 3 axes
+    REAL, DIMENSION(3) :: end !< start and end coordinates in 3 axes
+    REAL, ALLOCATABLE, DIMENSION(:) :: global_depth
+    REAL, ALLOCATABLE, DIMENSION(:) :: subaxis_z !< containing local coordinates in x,y,z axes
+    INTEGER :: i, global_axis_size
+    INTEGER, DIMENSION(3) :: gstart_indx !< global start and end indices of output domain in 3 axes
+    INTEGER, DIMENSION(3) :: gend_indx !< global start and end indices of output domain in 3 axes
+    CHARACTER(len=1) :: cart
+    CHARACTER(len=128) :: msg
+!----------
+!ug support
+    integer :: vert_dim_num
+!----------
+
+    !initilization for local output
+    start = -1.e10
+    end = -1.e10 ! initially out of (lat/lon/depth) range
+    gstart_indx = -1
+    gend_indx=-1
+
+    ! get axis data (lat, lon, depth) and indices
+    start= output_fields(outnum)%output_grid%start
+    end = output_fields(outnum)%output_grid%end
+
+!----------
+!ug support
+    vert_dim_num = 3
+!----------
+    DO i = 1, SIZE(axes(:))
+       global_axis_size = get_axis_global_length(axes(i))
+       output_fields(outnum)%output_grid%subaxes(i) = -1
+       CALL get_diag_axis_cart(axes(i), cart)
+       SELECT CASE(cart)
+       CASE ('X')
+          ! <ERROR STATUS="FATAL">wrong order of axes, X should come first</ERROR>
+          IF ( i.NE.1 ) CALL error_mesg('diag_util_mod::get_subfield_vert_size',&
+               & 'wrong order of axes, X should come first',FATAL)
+          gstart_indx(i) = 1
+          gend_indx(i) = global_axis_size
+          output_fields(outnum)%output_grid%subaxes(i) = axes(i)
+       CASE ('Y')
+          ! <ERROR STATUS="FATAL">wrong order of axes, Y should come second</ERROR>
+          IF( i.NE.2 ) CALL error_mesg('diag_util_mod::get_subfield_vert_size',&
+               & 'wrong order of axes, Y should come second',FATAL)
+          gstart_indx(i) = 1
+          gend_indx(i) = global_axis_size
+          output_fields(outnum)%output_grid%subaxes(i) = axes(i)
+!----------
+!ug support
+       case ("U")
+           if (i .ne. 1) then
+               call error_mesg("diag_util_mod::get_subfield_vert_size", &
+                               "the unstructured axis must be the first dimension.", &
+                               FATAL)
+           endif
+           gstart_indx(i) = 1
+           gend_indx(i) = global_axis_size
+           output_fields(outnum)%output_grid%subaxes(i) = axes(i)
+           vert_dim_num = 2
+           start(vert_dim_num) = start(3)
+           end(vert_dim_num) = end(3)
+!----------
+       CASE ('Z')
+!----------
+!ug support
+          if (i .ne. vert_dim_num) then
+              call error_mesg("diag_util_mod::get_subfield_vert_size",&
+                              "i should equal vert_dim_num for z axis", &
+                              FATAL)
+          endif
+!----------
+          ! <ERROR STATUS="FATAL">wrong values in vertical axis of region</ERROR>
+          IF( start(i)*END(i) < 0. ) CALL error_mesg('diag_util_mod::get_subfield_vert_size',&
+               & 'wrong values in vertical axis of region',FATAL)
+          IF( start(i) >= 0. .AND. END(i) > 0. ) THEN
+             ALLOCATE(global_depth(global_axis_size))
+             CALL get_diag_axis_data(axes(i),global_depth)
+             gstart_indx(i) = get_index(start(i),global_depth)
+             IF( start(i) == 0.0 )  gstart_indx(i) = 1
+
+             gend_indx(i) = get_index(END(i),global_depth)
+             IF( start(i) >= MAXVAL(global_depth) ) gstart_indx(i)= global_axis_size
+             IF( END(i)   >= MAXVAL(global_depth) ) gend_indx(i)  = global_axis_size
+
+             ALLOCATE(subaxis_z(gstart_indx(i):gend_indx(i)))
+             subaxis_z=global_depth(gstart_indx(i):gend_indx(i))
+             output_fields(outnum)%output_grid%subaxes(i) = &
+                    diag_subaxes_init(axes(i),subaxis_z, gstart_indx(i),gend_indx(i))
+             DEALLOCATE(subaxis_z,global_depth)
+          ELSE !   vertical axis is the same as global vertical axis
+             gstart_indx(i) = 1
+             gend_indx(i) = global_axis_size
+             output_fields(outnum)%output_grid%subaxes(i) = axes(i)
+          END IF
+       CASE default
+          ! <ERROR STATUS="FATAL">Wrong axis_cart</ERROR>
+          CALL error_mesg('diag_util_mod::get_subfield_vert_size', 'Wrong axis_cart', FATAL)
+       END SELECT
+    END DO
+
+    DO i = 1,SIZE(axes(:))
+       IF ( gstart_indx(i) == -1 .OR. gend_indx(i) == -1 ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   can not find gstart_indx/gend_indx for <output_fields(outnum)%output_name>
+          !   check region bounds for axis
+          ! </ERROR>
+          WRITE(msg,'(A,I2)') ' check region bounds for axis ', i
+          CALL error_mesg('diag_util_mod::get_subfield_vert_size', 'can not find gstart_indx/gend_indx for '&
+               & //TRIM(output_fields(outnum)%output_name)//','//TRIM(msg), FATAL)
+       END IF
+    END DO
+
+    DO i= 1, 2
+       output_fields(outnum)%output_grid%l_start_indx(i) = gstart_indx(i)
+       output_fields(outnum)%output_grid%l_end_indx(i)   = gend_indx(i)
+    END DO
+
+    IF( SIZE(axes(:)) > 2 ) THEN
+       output_fields(outnum)%output_grid%l_start_indx(3) = gstart_indx(3)
+       output_fields(outnum)%output_grid%l_end_indx(3)   = gend_indx(3)
+    ELSE
+       output_fields(outnum)%output_grid%l_start_indx(3) = 1
+       output_fields(outnum)%output_grid%l_end_indx(3)   = 1
+    END IF
+  END SUBROUTINE get_subfield_vert_size
+
+  !> @brief Find index <TT>i</TT> of array such that <TT>array(i)</TT> is closest to number.
+  INTEGER FUNCTION get_index(number, array)
+    REAL, INTENT(in) :: number !<
+    REAL, INTENT(in), DIMENSION(:) :: array !<
+
+    INTEGER :: i, n
+    LOGICAL :: found
+
+    n = SIZE(array(:))
+    ! check if array is monotonous
+    DO i = 2, n-1
+       IF( (array(i-1)<array(i).AND.array(i)>array(i+1)) .OR. (array(i-1)>array(i).AND.array(i)<array(i+1))) THEN
+          ! <ERROR STATUS="FATAL">array NOT monotonously ordered</ERROR>
+          CALL error_mesg('diag_util_mod::get_index', 'array NOT monotonously ordered',FATAL)
+       END IF
+    END DO
+    get_index = -1
+    found = .FALSE.
+    ! search in increasing array
+    DO i = 1, n-1
+       IF ( (array(i)<=number).AND.(array(i+1)>= number) ) THEN
+          IF( number - array(i) <= array(i+1) - number ) THEN
+             get_index = i
+             found=.TRUE.
+          ELSE
+             get_index = i+1
+             found=.TRUE.
+          ENDIF
+          EXIT
+       END IF
+    END DO
+    ! if not found, search in decreasing array
+    IF( .NOT.found ) THEN
+       DO i = 1, n-1
+          IF ( (array(i)>=number).AND.(array(i+1)<= number) ) THEN
+             IF ( array(i)-number <= number-array(i+1) ) THEN
+                get_index = i
+                found = .TRUE.
+             ELSE
+                get_index = i+1
+                found = .TRUE.
+             END IF
+             EXIT
+          END IF
+       END DO
+    END IF
+    ! if still not found, is it less than the first element
+    ! or greater than last element? (Increasing Array)
+    ! But it must be within 2x the axis spacing
+    ! i.e. array(1)-(array(3)-array(1)).LT.number .AND. or 2*array(1)-array(3).LT.number
+    IF ( .NOT. found ) THEN
+       IF ( 2*array(1)-array(3).LT.number .AND. number.LT.array(1) ) THEN
+          get_index = 1
+          found = .TRUE.
+       ELSE IF ( array(n).LT.number .AND. number.LT.2*array(n)-array(n-2) ) THEN
+          get_index = n
+          found = .TRUE.
+       ELSE
+          found = .FALSE.
+       END IF
+    END IF
+
+    ! if still not found, is it greater than the first element
+    ! or less than the last element? (Decreasing Array)
+    ! But it must be within 2x the axis spacing (see above)
+    IF ( .NOT. found ) THEN
+       IF ( 2*array(1)-array(3).GT.number .AND. number.GT.array(1) ) THEN
+          get_index = 1
+          found = .TRUE.
+       ELSE IF ( array(n).GT.number .AND. number.GT.2*array(n)-array(n-2) ) THEN
+          get_index = n
+          found = .TRUE.
+       ELSE
+          found = .FALSE.
+       END IF
+    END IF
+  END FUNCTION get_index
+
+  !> @brief Writes brief diagnostic field info to the log file.
+  !! @details If the <TT>do_diag_field_log</TT> namelist parameter is .TRUE.,
+  !!     then a line briefly describing diagnostic field is added to
+  !!     the log file.  Normally users should not call this subroutine
+  !!     directly, since it is called by register_static_field and
+  !!     register_diag_field if do_not_log is not set to .TRUE..  It is
+  !!     used, however, in LM3 to avoid excessive logs due to the
+  !!     number of fields registered for each of the tile types.  LM3
+  !!     code uses a do_not_log parameter in the registration calls,
+  !!     and subsequently calls this subroutine to log field information
+  !!     under a generic name.
+  SUBROUTINE log_diag_field_info(module_name, field_name, axes, long_name, units,&
+       & missing_value, range, dynamic)
+    CHARACTER(len=*), INTENT(in) :: module_name !< Module name
+    CHARACTER(len=*), INTENT(in) :: field_name !< Field name
+    INTEGER, DIMENSION(:), INTENT(in) :: axes !< Axis IDs
+    CHARACTER(len=*), OPTIONAL, INTENT(in) :: long_name !< Long name for field.
+    CHARACTER(len=*), OPTIONAL, INTENT(in) :: units !< Unit of field.
+    REAL, OPTIONAL, INTENT(in) :: missing_value !< Missing value value.
+    REAL, DIMENSION(2), OPTIONAL, INTENT(IN) :: range !< Valid range of values for field.
+    LOGICAL, OPTIONAL, INTENT(in) :: dynamic !< <TT>.TRUE.</TT> if field is not static.
+
+    ! ---- local vars
+    CHARACTER(len=256) :: lmodule, lfield, lname, lunits
+    CHARACTER(len=64)  :: lmissval, lmin, lmax
+    CHARACTER(len=8)   :: numaxis, timeaxis
+    CHARACTER(len=1)   :: sep = '|'
+    CHARACTER(len=256) :: axis_name, axes_list
+    INTEGER :: i
+
+    IF ( .NOT.do_diag_field_log ) RETURN
+    IF ( mpp_pe().NE.mpp_root_pe() ) RETURN
+
+    lmodule = TRIM(module_name)
+    lfield = TRIM(field_name)
+
+    IF ( PRESENT(long_name) ) THEN
+       lname  = TRIM(long_name)
+    ELSE
+       lname  = ''
+    END IF
+
+    IF ( PRESENT(units) ) THEN
+       lunits = TRIM(units)
+    ELSE
+       lunits = ''
+    END IF
+
+    WRITE (numaxis,'(i1)') SIZE(axes)
+
+    IF (PRESENT(missing_value)) THEN
+       IF ( use_cmor ) THEN
+          WRITE (lmissval,*) CMOR_MISSING_VALUE
+       ELSE
+          WRITE (lmissval,*) missing_value
+       END IF
+    ELSE
+       lmissval = ''
+    ENDIF
+
+    IF ( PRESENT(range) ) THEN
+       WRITE (lmin,*) range(1)
+       WRITE (lmax,*) range(2)
+    ELSE
+       lmin = ''
+       lmax = ''
+    END IF
+
+    IF ( PRESENT(dynamic) ) THEN
+       IF (dynamic) THEN
+          timeaxis = 'T'
+       ELSE
+          timeaxis = 'F'
+       END IF
+    ELSE
+       timeaxis = ''
+    END IF
+
+    axes_list=''
+    DO i = 1, SIZE(axes)
+       CALL get_diag_axis_name(axes(i),axis_name)
+       IF ( TRIM(axes_list) /= '' ) axes_list = TRIM(axes_list)//','
+       axes_list = TRIM(axes_list)//TRIM(axis_name)
+    END DO
+
+    !write (diag_log_unit,'(8(a,a),a)') &
+    WRITE (diag_log_unit,'(777a)') &
+         & TRIM(lmodule),  sep, TRIM(lfield),  sep, TRIM(lname),    sep,&
+         & TRIM(lunits),   sep, TRIM(numaxis), sep, TRIM(timeaxis), sep,&
+         & TRIM(lmissval), sep, TRIM(lmin),    sep, TRIM(lmax),     sep,&
+         & TRIM(axes_list)
+  END SUBROUTINE log_diag_field_info
+
+  !> @brief Update the <TT>output_fields</TT> x, y, and z min and max boundaries (array indices).
+  SUBROUTINE update_bounds(out_num, lower_i, upper_i, lower_j, upper_j, lower_k, upper_k)
+    INTEGER, INTENT(in) :: out_num !< output field ID
+    INTEGER, INTENT(in) :: lower_i !< Lower i bound.
+    INTEGER, INTENT(in) :: upper_i !< Upper i bound.
+    INTEGER, INTENT(in) :: lower_j !< Lower j bound.
+    INTEGER, INTENT(in) :: upper_j !< Upper j bound.
+    INTEGER, INTENT(in) :: lower_k !< Lower k bound.
+    INTEGER, INTENT(in) :: upper_k !< Upper k bound.
+
+    output_fields(out_num)%imin = MIN(output_fields(out_num)%imin, lower_i)
+    output_fields(out_num)%imax = MAX(output_fields(out_num)%imax, upper_i)
+    output_fields(out_num)%jmin = MIN(output_fields(out_num)%jmin, lower_j)
+    output_fields(out_num)%jmax = MAX(output_fields(out_num)%jmax, upper_j)
+    output_fields(out_num)%kmin = MIN(output_fields(out_num)%kmin, lower_k)
+    output_fields(out_num)%kmax = MAX(output_fields(out_num)%kmax, upper_k)
+  END SUBROUTINE update_bounds
+
+  !> @brief Checks if the array indices for <TT>output_fields(out_num)</TT> are outside the <TT>output_fields(out_num)%buffer</TT> upper
+  !!     and lower bounds.
+  SUBROUTINE check_out_of_bounds(out_num, diag_field_id, err_msg)
+    INTEGER, INTENT(in) :: out_num !< Output field ID number.
+    INTEGER, INTENT(in) :: diag_field_id !< Input field ID number.
+    CHARACTER(len=*), INTENT(out) :: err_msg !< Return status of <TT>check_out_of_bounds</TT>.  An empty error string indicates the x, y, and z indices are not outside the
+                                             !!     buffer array boundaries.
+
+    CHARACTER(len=128) :: error_string1, error_string2
+
+    IF (   output_fields(out_num)%imin < LBOUND(output_fields(out_num)%buffer,1) .OR.&
+         & output_fields(out_num)%imax > UBOUND(output_fields(out_num)%buffer,1) .OR.&
+         & output_fields(out_num)%jmin < LBOUND(output_fields(out_num)%buffer,2) .OR.&
+         & output_fields(out_num)%jmax > UBOUND(output_fields(out_num)%buffer,2) .OR.&
+         & output_fields(out_num)%kmin < LBOUND(output_fields(out_num)%buffer,3) .OR.&
+         & output_fields(out_num)%kmax > UBOUND(output_fields(out_num)%buffer,3) ) THEN
+       WRITE(error_string1,'(a,"/",a)') TRIM(input_fields(diag_field_id)%module_name),&
+            & TRIM(output_fields(out_num)%output_name)
+       error_string2 ='Buffer bounds=   :   ,   :   ,   :     Actual bounds=   :   ,   :   ,   :   '
+       WRITE(error_string2(15:17),'(i3)') LBOUND(output_fields(out_num)%buffer,1)
+       WRITE(error_string2(19:21),'(i3)') UBOUND(output_fields(out_num)%buffer,1)
+       WRITE(error_string2(23:25),'(i3)') LBOUND(output_fields(out_num)%buffer,2)
+       WRITE(error_string2(27:29),'(i3)') UBOUND(output_fields(out_num)%buffer,2)
+       WRITE(error_string2(31:33),'(i3)') LBOUND(output_fields(out_num)%buffer,3)
+       WRITE(error_string2(35:37),'(i3)') UBOUND(output_fields(out_num)%buffer,3)
+       WRITE(error_string2(54:56),'(i3)') output_fields(out_num)%imin
+       WRITE(error_string2(58:60),'(i3)') output_fields(out_num)%imax
+       WRITE(error_string2(62:64),'(i3)') output_fields(out_num)%jmin
+       WRITE(error_string2(66:68),'(i3)') output_fields(out_num)%jmax
+       WRITE(error_string2(70:72),'(i3)') output_fields(out_num)%kmin
+       WRITE(error_string2(74:76),'(i3)') output_fields(out_num)%kmax
+       err_msg = 'module/output_field='//TRIM(error_string1)//&
+            & '  Bounds of buffer exceeded.  '//TRIM(error_string2)
+       !   imax, imin, etc need to be reset in case the program is not terminated.
+       output_fields(out_num)%imax = 0
+       output_fields(out_num)%imin = VERY_LARGE_AXIS_LENGTH
+       output_fields(out_num)%jmax = 0
+       output_fields(out_num)%jmin = VERY_LARGE_AXIS_LENGTH
+       output_fields(out_num)%kmax = 0
+       output_fields(out_num)%kmin = VERY_LARGE_AXIS_LENGTH
+    ELSE
+       err_msg = ''
+    END IF
+
+  END SUBROUTINE check_out_of_bounds
+
+  !> @brief  Check if the array indices for <TT>output_fields(out_num)</TT> are equal to the <TT>output_fields(out_num)%buffer</TT>
+  !!     upper and lower bounds.
+  SUBROUTINE check_bounds_are_exact_dynamic(out_num, diag_field_id, Time, err_msg)
+    INTEGER, INTENT(in) :: out_num !< Output field ID number.
+    INTEGER, INTENT(in) :: diag_field_id !< Input field ID number.
+    TYPE(time_type), INTENT(in) :: Time !< Time to use in check.  The check is only performed if
+                                        !! <TT>output_fields(out_num)%Time_of_prev_field_data</TT> is not
+                                        !! equal to <TT>Time</TT> or <TT>Time_zero</TT>.
+    CHARACTER(len=*), INTENT(out) :: err_msg !< Return status of <TT>check_bounds_are_exact_dynamic</TT>.
+                                             !! An empty error string indicates the x, y, and z indices are
+                                             !!     equal to the buffer array boundaries.
+
+    CHARACTER(len=128) :: error_string1, error_string2
+    LOGICAL :: do_check
+
+    err_msg = ''
+
+    ! Check bounds only when the value of Time changes. When windows are used,
+    ! a change in Time indicates that a new loop through the windows has begun,
+    !  so a check of the previous loop can be done.
+    IF ( Time == output_fields(out_num)%Time_of_prev_field_data ) THEN
+       do_check = .FALSE.
+    ELSE
+       IF ( output_fields(out_num)%Time_of_prev_field_data == Time_zero ) THEN
+          ! It may or may not be OK to check, I don't know how to tell.
+          ! Check will be done on subsequent calls anyway.
+          do_check = .FALSE.
+       ELSE
+          do_check = .TRUE.
+       END IF
+       output_fields(out_num)%Time_of_prev_field_data = Time
+    END IF
+
+    IF ( do_check ) THEN
+       IF (   output_fields(out_num)%imin /= LBOUND(output_fields(out_num)%buffer,1) .OR.&
+            & output_fields(out_num)%imax /= UBOUND(output_fields(out_num)%buffer,1) .OR.&
+            & output_fields(out_num)%jmin /= LBOUND(output_fields(out_num)%buffer,2) .OR.&
+            & output_fields(out_num)%jmax /= UBOUND(output_fields(out_num)%buffer,2) .OR.&
+            & output_fields(out_num)%kmin /= LBOUND(output_fields(out_num)%buffer,3) .OR.&
+            & output_fields(out_num)%kmax /= UBOUND(output_fields(out_num)%buffer,3) ) THEN
+          WRITE(error_string1,'(a,"/",a)') TRIM(input_fields(diag_field_id)%module_name),&
+               & TRIM(output_fields(out_num)%output_name)
+          error_string2 ='Buffer bounds=   :   ,   :   ,   :     Actual bounds=   :   ,   :   ,   :   '
+          WRITE(error_string2(15:17),'(i3)') LBOUND(output_fields(out_num)%buffer,1)
+          WRITE(error_string2(19:21),'(i3)') UBOUND(output_fields(out_num)%buffer,1)
+          WRITE(error_string2(23:25),'(i3)') LBOUND(output_fields(out_num)%buffer,2)
+          WRITE(error_string2(27:29),'(i3)') UBOUND(output_fields(out_num)%buffer,2)
+          WRITE(error_string2(31:33),'(i3)') LBOUND(output_fields(out_num)%buffer,3)
+          WRITE(error_string2(35:37),'(i3)') UBOUND(output_fields(out_num)%buffer,3)
+          WRITE(error_string2(54:56),'(i3)') output_fields(out_num)%imin
+          WRITE(error_string2(58:60),'(i3)') output_fields(out_num)%imax
+          WRITE(error_string2(62:64),'(i3)') output_fields(out_num)%jmin
+          WRITE(error_string2(66:68),'(i3)') output_fields(out_num)%jmax
+          WRITE(error_string2(70:72),'(i3)') output_fields(out_num)%kmin
+          WRITE(error_string2(74:76),'(i3)') output_fields(out_num)%kmax
+          err_msg = TRIM(error_string1)//' Bounds of data do not match those of buffer. '//TRIM(error_string2)
+       END IF
+       output_fields(out_num)%imax = 0
+       output_fields(out_num)%imin = VERY_LARGE_AXIS_LENGTH
+       output_fields(out_num)%jmax = 0
+       output_fields(out_num)%jmin = VERY_LARGE_AXIS_LENGTH
+       output_fields(out_num)%kmax = 0
+       output_fields(out_num)%kmin = VERY_LARGE_AXIS_LENGTH
+    END IF
+  END SUBROUTINE check_bounds_are_exact_dynamic
+
+  !> @brief Check if the array indices for <TT>output_fields(out_num)</TT> are equal to the <TT>output_fields(out_num)%buffer</TT>
+  !!     upper and lower bounds.
+  SUBROUTINE check_bounds_are_exact_static(out_num, diag_field_id, err_msg)
+    INTEGER, INTENT(in) :: out_num !< Output field ID
+    INTEGER, INTENT(in) :: diag_field_id !< Input field ID.
+    CHARACTER(len=*), INTENT(out) :: err_msg
+
+    CHARACTER(len=128)  :: error_string1, error_string2
+
+    err_msg = ''
+
+    IF (   output_fields(out_num)%imin /= LBOUND(output_fields(out_num)%buffer,1) .OR.&
+         & output_fields(out_num)%imax /= UBOUND(output_fields(out_num)%buffer,1) .OR.&
+         & output_fields(out_num)%jmin /= LBOUND(output_fields(out_num)%buffer,2) .OR.&
+         & output_fields(out_num)%jmax /= UBOUND(output_fields(out_num)%buffer,2) .OR.&
+         & output_fields(out_num)%kmin /= LBOUND(output_fields(out_num)%buffer,3) .OR.&
+         & output_fields(out_num)%kmax /= UBOUND(output_fields(out_num)%buffer,3) ) THEN
+       WRITE(error_string1,'(a,"/",a)') TRIM(input_fields(diag_field_id)%module_name),&
+            & TRIM(output_fields(out_num)%output_name)
+       error_string2 ='Buffer bounds=   :   ,   :   ,   :     Actual bounds=   :   ,   :   ,   :   '
+       WRITE(error_string2(15:17),'(i3)') LBOUND(output_fields(out_num)%buffer,1)
+       WRITE(error_string2(19:21),'(i3)') UBOUND(output_fields(out_num)%buffer,1)
+       WRITE(error_string2(23:25),'(i3)') LBOUND(output_fields(out_num)%buffer,2)
+       WRITE(error_string2(27:29),'(i3)') UBOUND(output_fields(out_num)%buffer,2)
+       WRITE(error_string2(31:33),'(i3)') LBOUND(output_fields(out_num)%buffer,3)
+       WRITE(error_string2(35:37),'(i3)') UBOUND(output_fields(out_num)%buffer,3)
+       WRITE(error_string2(54:56),'(i3)') output_fields(out_num)%imin
+       WRITE(error_string2(58:60),'(i3)') output_fields(out_num)%imax
+       WRITE(error_string2(62:64),'(i3)') output_fields(out_num)%jmin
+       WRITE(error_string2(66:68),'(i3)') output_fields(out_num)%jmax
+       WRITE(error_string2(70:72),'(i3)') output_fields(out_num)%kmin
+       WRITE(error_string2(74:76),'(i3)') output_fields(out_num)%kmax
+       err_msg = TRIM(error_string1)//' Bounds of data do not match those of buffer. '//TRIM(error_string2)
+    END IF
+    output_fields(out_num)%imax = 0
+    output_fields(out_num)%imin = VERY_LARGE_AXIS_LENGTH
+    output_fields(out_num)%jmax = 0
+    output_fields(out_num)%jmin = VERY_LARGE_AXIS_LENGTH
+    output_fields(out_num)%kmax = 0
+    output_fields(out_num)%kmin = VERY_LARGE_AXIS_LENGTH
+
+  END SUBROUTINE check_bounds_are_exact_static
+
+  !> @brief Initialize the output file.
+  SUBROUTINE init_file(name, output_freq, output_units, format, time_units, long_name, tile_count,&
+       & new_file_freq, new_file_freq_units, start_time, file_duration, file_duration_units, filename_time_bounds)
+    CHARACTER(len=*), INTENT(in) :: name !< File name.
+    CHARACTER(len=*), INTENT(in) :: long_name !< Long name for time axis.
+    INTEGER, INTENT(in) :: output_freq !< How often data is to be written to the file.
+    INTEGER, INTENT(in) :: output_units !< The output frequency unit.  (MIN, HOURS, DAYS, etc.)
+    INTEGER, INTENT(in) :: format !< Number type/kind the data is to be written out to the file.
+    INTEGER, INTENT(in) :: time_units !< Time axis units.
+    INTEGER, INTENT(in) :: tile_count !< Tile number.
+    INTEGER, INTENT(in), OPTIONAL :: new_file_freq !< How often a new file is to be created.
+    INTEGER, INTENT(in), OPTIONAL :: new_file_freq_units !< The new file frequency unit.  (MIN, HOURS, DAYS, etc.)</IN>
+    INTEGER, INTENT(in), OPTIONAL :: file_duration !< How long file is to be used.
+    INTEGER, INTENT(in), OPTIONAL :: file_duration_units !< File duration unit.  (MIN, HOURS, DAYS, etc.)
+    TYPE(time_type), INTENT(in), OPTIONAL :: start_time !< Time when the file is to start
+    CHARACTER(len=*), INTENT(in), OPTIONAL :: filename_time_bounds !< Set time bound file name to
+                                                                   ! use "begin" "middle" or "end"
+    INTEGER :: new_file_freq1, new_file_freq_units1
+    INTEGER :: file_duration1, file_duration_units1
+    INTEGER :: n
+    LOGICAL :: same_file_err !< .FALSE. indicates that if the file name had
+                             !! previously been registered, this new file
+                             !! contained differences from the previous.
+    REAL, DIMENSION(1) :: tdata
+    CHARACTER(len=128) :: time_units_str
+
+    ! Check if this file has already been defined
+    same_file_err=.FALSE. ! To indicate that if this file was previously defined
+                          ! no differences in this registration was detected.
+    DO n=1,num_files
+      IF ( TRIM(files(n)%name) == TRIM(name) ) THEN
+        ! File is defined, check if all inputs are the same
+        ! Start with the required parameters
+        IF ( files(n)%output_freq.NE.output_freq .OR.&
+           & files(n)%output_units.NE.output_units .OR.&
+           & files(n)%format.NE.format .OR.&
+           & files(n)%time_units.NE.time_units .OR.&
+           & TRIM(files(n)%long_name).NE.TRIM(long_name) .OR.&
+           & files(n)%tile_count.NE.tile_count ) THEN
+           same_file_err=.TRUE.
+        END IF
+
+        ! Now check the OPTIONAL parameters
+        IF ( PRESENT(new_file_freq) ) THEN
+           IF ( files(n)%new_file_freq.NE.new_file_freq ) THEN
+             same_file_err=.TRUE.
+           END IF
+        END IF
+
+        IF ( PRESENT(new_file_freq_units) ) THEN
+          IF ( files(n)%new_file_freq_units.NE.new_file_freq_units ) THEN
+            same_file_err=.TRUE.
+          END IF
+        END IF
+
+        IF ( PRESENT(start_time) ) THEN
+          IF ( files(n)%start_time==start_time ) THEN
+            same_file_err=.TRUE.
+          END IF
+        END IF
+
+        IF ( PRESENT(file_duration) ) THEN
+          IF ( files(n)%duration.NE.file_duration) THEN
+            same_file_err=.TRUE.
+          END IF
+        END IF
+
+        IF ( PRESENT(file_duration_units) ) THEN
+          IF ( files(n)%duration_units.NE.file_duration_units ) THEN
+            same_file_err=.TRUE.
+          END IF
+        END IF
+
+        ! If the same file was defined twice, simply return, else FATAL
+        IF ( same_file_err ) THEN
+          ! Something in this file is not identical to the previously defined
+          ! file of the same name.  FATAL
+          CALL error_mesg('diag_util_mod::init_file',&
+                  & 'The file "'//TRIM(name)//'" is defined multiple times in&
+                  & the diag_table.', FATAL)
+        ELSE
+          ! Issue a note that the same file is defined multiple times
+          CALL error_mesg('diag_util_mod::init_file',&
+                  & 'The file "'//TRIM(name)//'" is defined multiple times in&
+                  & the diag_table.', NOTE)
+          ! Return to the calling function
+          RETURN
+        END IF
+      END IF
+    END DO
+
+    ! Get a number for this file
+    num_files = num_files + 1
+    IF ( num_files >= max_files ) THEN
+       ! <ERROR STATUS="FATAL">
+       !   max_files exceeded, increase max_files via the max_files variable
+       !   in the namelist diag_manager_nml.
+       ! </ERROR>
+       CALL error_mesg('diag_util_mod::init_file',&
+            & ' max_files exceeded, increase max_files via the max_files variable&
+            & in the namelist diag_manager_nml.', FATAL)
+    END IF
+
+    IF ( PRESENT(new_file_freq) ) THEN
+       new_file_freq1 = new_file_freq
+    ELSE
+       new_file_freq1 = VERY_LARGE_FILE_FREQ
+    END IF
+
+    IF ( PRESENT(new_file_freq_units) ) THEN
+       new_file_freq_units1 = new_file_freq_units
+    ELSE IF ( get_calendar_type() == NO_CALENDAR ) THEN
+       new_file_freq_units1 = DIAG_DAYS
+    ELSE
+       new_file_freq_units1 = DIAG_YEARS
+    END IF
+
+    IF ( PRESENT(file_duration) ) THEN
+       file_duration1 = file_duration
+    ELSE
+       file_duration1 = new_file_freq1
+    END IF
+
+    IF ( PRESENT(file_duration_units) ) THEN
+       file_duration_units1 = file_duration_units
+    ELSE
+       file_duration_units1 = new_file_freq_units1
+    END IF
+
+    files(num_files)%tile_count = tile_count
+    files(num_files)%name = TRIM(name)
+    files(num_files)%output_freq = output_freq
+    files(num_files)%output_units = output_units
+    files(num_files)%format = FORMAT
+    files(num_files)%time_units = time_units
+    files(num_files)%long_name = TRIM(long_name)
+    files(num_files)%num_fields = 0
+    files(num_files)%local = .FALSE.
+    files(num_files)%last_flush = base_time
+    files(num_files)%file_unit = -1
+    files(num_files)%new_file_freq = new_file_freq1
+    files(num_files)%new_file_freq_units = new_file_freq_units1
+    files(num_files)%duration = file_duration1
+    files(num_files)%duration_units = file_duration_units1
+!> Initialize the times to 0
+    files(num_files)%rtime_current = -1.0
+    files(num_files)%time_index = 0
+    files(num_files)%filename_time_bounds = filename_time_bounds
+
+    IF ( PRESENT(start_time) ) THEN
+       files(num_files)%start_time = start_time
+    ELSE
+       files(num_files)%start_time = base_time
+    END IF
+    files(num_files)%next_open=diag_time_inc(files(num_files)%start_time,new_file_freq1,new_file_freq_units1)
+    files(num_files)%close_time = diag_time_inc(files(num_files)%start_time,file_duration1, file_duration_units1)
+    IF ( files(num_files)%close_time>files(num_files)%next_open ) THEN
+       ! <ERROR STATUS="FATAL">
+       !   close time GREATER than next_open time, check file duration,
+       !   file frequency in <files(num_files)%name>
+       ! </ERROR>
+       CALL error_mesg('diag_util_mod::init_file', 'close time GREATER than next_open time, check file duration,&
+            & file frequency in '//files(num_files)%name, FATAL)
+    END IF
+
+    ! add time_axis_id and time_bounds_id here
+    WRITE(time_units_str, 11) TRIM(time_unit_list(files(num_files)%time_units)), base_year,&
+         & base_month, base_day, base_hour, base_minute, base_second
+11  FORMAT(a, ' since ', i4.4, '-', i2.2, '-', i2.2, ' ', i2.2, ':', i2.2, ':', i2.2)
+    files(num_files)%time_axis_id = diag_axis_init (TRIM(long_name), tdata, time_units_str, 'T',&
+         & TRIM(long_name) , set_name=TRIM(name) )
+    !---- register axis for storing time boundaries
+    files(num_files)%time_bounds_id = diag_axis_init( 'nbnd',(/1.,2./),'none','N','bounds',&
+         & set_name='nbnd')
+  END SUBROUTINE init_file
+
+  !> @brief Synchronize the file's start and close times with the model start and end times.
+  !! @details <TT>sync_file_times</TT> checks to see if the file start time is less than the
+  !!     model's init time (passed in as the only argument).  If it is less, then the
+  !!     both the file start time and end time are synchronized using the passed in initial time
+  !!     and the duration as calculated by the <TT>diag_time_inc</TT> function.  <TT>sync_file_times</TT>
+  !!     will also increase the <TT>next_open</TT> until it is greater than the init_time.
+  SUBROUTINE sync_file_times(file_id, init_time, err_msg)
+    INTEGER, INTENT(in) :: file_id !< The file ID
+    TYPE(time_type), INTENT(in) :: init_time !< Initial time use for the synchronization.
+    CHARACTER(len=*), OPTIONAL, INTENT(out) :: err_msg !< Return error message
+
+    CHARACTER(len=128) :: msg
+
+    IF ( PRESENT(err_msg) ) err_msg = ''
+
+    IF ( files(file_id)%start_time < init_time ) THEN
+       ! Sync the start_time of the file with the initial time of the model
+       files(file_id)%start_time = init_time
+       ! Sync the file's close time also
+       files(file_id)%close_time = diag_time_inc(files(file_id)%start_time,&
+            & files(file_id)%duration, files(file_id)%duration_units)
+    END IF
+
+    ! Need to increase next_open until it is greate than init_time
+    DO WHILE ( files(file_id)%next_open <= init_time )
+       files(file_id)%next_open = diag_time_inc(files(file_id)%next_open,&
+            & files(file_id)%new_file_freq, files(file_id)%new_file_freq_units, err_msg=msg)
+       IF ( msg /= '' ) THEN
+          IF ( fms_error_handler('diag_util_mod::sync_file_times',&
+               & ' file='//TRIM(files(file_id)%name)//': '//TRIM(msg), err_msg) ) RETURN
+       END IF
+    END DO
+  END SUBROUTINE sync_file_times
+
+  !> @brief Return the next time data/file is to be written based on the frequency and units.
+  TYPE(time_type) FUNCTION diag_time_inc(time, output_freq, output_units, err_msg)
+    TYPE(time_type), INTENT(in) :: time !< Current model time.
+    INTEGER, INTENT(in):: output_freq !< Output frequency number value.
+    INTEGER, INTENT(in):: output_units !< Output frequency unit.
+    CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg !< Function error message.
+                                                       !! An empty string indicates the next output
+                                                       !! time was found successfully.
+
+    CHARACTER(len=128) :: error_message_local
+
+    IF ( PRESENT(err_msg) ) err_msg = ''
+    error_message_local = ''
+
+    ! special values for output frequency are -1 for output at end of run
+    ! and 0 for every timestep.  Need to check for these here?
+    ! Return zero time increment, hopefully this value is never used
+    IF ( output_freq == END_OF_RUN .OR. output_freq == EVERY_TIME ) THEN
+       diag_time_inc = time
+       RETURN
+    END IF
+
+    ! Make sure calendar was not set after initialization
+    IF ( output_units == DIAG_SECONDS ) THEN
+       IF ( get_calendar_type() == NO_CALENDAR ) THEN
+          diag_time_inc = increment_time(time, output_freq, 0, err_msg=error_message_local)
+       ELSE
+          diag_time_inc = increment_date(time, 0, 0, 0, 0, 0, output_freq, err_msg=error_message_local)
+       END IF
+    ELSE IF ( output_units == DIAG_MINUTES ) THEN
+       IF ( get_calendar_type() == NO_CALENDAR ) THEN
+          diag_time_inc = increment_time(time, NINT(output_freq*SECONDS_PER_MINUTE), 0, &
+               &err_msg=error_message_local)
+       ELSE
+          diag_time_inc = increment_date(time, 0, 0, 0, 0, output_freq, 0, err_msg=error_message_local)
+       END IF
+    ELSE IF ( output_units == DIAG_HOURS ) THEN
+       IF ( get_calendar_type() == NO_CALENDAR ) THEN
+          diag_time_inc = increment_time(time, NINT(output_freq*SECONDS_PER_HOUR), 0, err_msg=error_message_local)
+       ELSE
+          diag_time_inc = increment_date(time, 0, 0, 0, output_freq, 0, 0, err_msg=error_message_local)
+       END IF
+    ELSE IF ( output_units == DIAG_DAYS ) THEN
+       IF (get_calendar_type() == NO_CALENDAR) THEN
+          diag_time_inc = increment_time(time, 0, output_freq, err_msg=error_message_local)
+       ELSE
+          diag_time_inc = increment_date(time, 0, 0, output_freq, 0, 0, 0, err_msg=error_message_local)
+       END IF
+    ELSE IF ( output_units == DIAG_MONTHS ) THEN
+       IF (get_calendar_type() == NO_CALENDAR) THEN
+          error_message_local = 'output units of months NOT allowed with no calendar'
+       ELSE
+          diag_time_inc = increment_date(time, 0, output_freq, 0, 0, 0, 0, err_msg=error_message_local)
+       END IF
+    ELSE IF ( output_units == DIAG_YEARS ) THEN
+       IF ( get_calendar_type() == NO_CALENDAR ) THEN
+          error_message_local = 'output units of years NOT allowed with no calendar'
+       ELSE
+          diag_time_inc = increment_date(time, output_freq, 0, 0, 0, 0, 0, err_msg=error_message_local)
+       END IF
+    ELSE
+       error_message_local = 'illegal output units'
+    END IF
+
+    IF ( error_message_local /= '' ) THEN
+       IF ( fms_error_handler('diag_time_inc',error_message_local,err_msg) ) RETURN
+    END IF
+  END FUNCTION diag_time_inc
+
+  !> @brief Return the file number for file name and tile.
+  !! @return Integer find_file
+  INTEGER FUNCTION find_file(name, tile_count)
+    INTEGER, INTENT(in) :: tile_count !< Tile number.
+    CHARACTER(len=*), INTENT(in) :: name !< File name.
+
+    INTEGER :: i
+
+    find_file = -1
+    DO i = 1, num_files
+       IF( TRIM(files(i)%name) == TRIM(name) .AND. tile_count == files(i)%tile_count ) THEN
+          find_file = i
+          RETURN
+       END IF
+    END DO
+  END FUNCTION find_file
+
+  !> @brief Return the field number for the given module name, field name, and tile number.
+  !! @return Integer find_input_field
+  INTEGER FUNCTION find_input_field(module_name, field_name, tile_count)
+    CHARACTER(len=*), INTENT(in) :: module_name !< Module name.
+    CHARACTER(len=*), INTENT(in) :: field_name !< field name.
+    INTEGER, INTENT(in) :: tile_count !< Tile number.
+
+    INTEGER :: i
+
+    find_input_field = DIAG_FIELD_NOT_FOUND ! Default return value if not found.
+    DO i = 1, num_input_fields
+       IF(tile_count == input_fields(i)%tile_count .AND.&
+            & TRIM(input_fields(i)%module_name) == TRIM(module_name) .AND.&
+            & lowercase(TRIM(input_fields(i)%field_name)) == lowercase(TRIM(field_name))) THEN
+          find_input_field = i
+          RETURN
+       END IF
+    END DO
+  END FUNCTION find_input_field
+
+  !> @brief Initialize the input field.
+  SUBROUTINE init_input_field(module_name, field_name, tile_count)
+    CHARACTER(len=*),  INTENT(in) :: module_name !< Module name.
+    CHARACTER(len=*),  INTENT(in) :: field_name !< Input field name.
+    INTEGER, INTENT(in) :: tile_count !< Tile number.
+
+    ! Get a number for this input_field if not already set up
+    IF ( find_input_field(module_name, field_name, tile_count) < 0 ) THEN
+       num_input_fields = num_input_fields + 1
+       IF ( num_input_fields > max_input_fields ) THEN
+          ! <ERROR STATUS="FATAL">max_input_fields exceeded, increase it via diag_manager_nml</ERROR>
+          CALL error_mesg('diag_util_mod::init_input_field',&
+               & 'max_input_fields exceeded, increase it via diag_manager_nml', FATAL)
+       END IF
+    ELSE
+       ! If this is already initialized do not need to do anything
+       RETURN
+    END IF
+
+    input_fields(num_input_fields)%module_name = TRIM(module_name)
+    input_fields(num_input_fields)%field_name = TRIM(field_name)
+    input_fields(num_input_fields)%num_output_fields = 0
+    ! Set flag that this field has not been registered
+    input_fields(num_input_fields)%register = .FALSE.
+    input_fields(num_input_fields)%local = .FALSE.
+    input_fields(num_input_fields)%standard_name = 'none'
+    input_fields(num_input_fields)%tile_count = tile_count
+    input_fields(num_input_fields)%numthreads = 1
+    input_fields(num_input_fields)%active_omp_level = 0
+    input_fields(num_input_fields)%time = time_zero
+  END SUBROUTINE init_input_field
+
+  !> @brief Initialize the output field.
+  SUBROUTINE init_output_field(module_name, field_name, output_name, output_file,&
+       & time_method, pack, tile_count, local_coord)
+    CHARACTER(len=*), INTENT(in) :: module_name !< Module name.
+    CHARACTER(len=*), INTENT(in) :: field_name !< Output field name.
+    CHARACTER(len=*), INTENT(in) :: output_name !< Output name written to file.
+    CHARACTER(len=*), INTENT(in) :: output_file !< File where field should be written.
+    CHARACTER(len=*), INTENT(in) :: time_method !< Data reduction method.
+                                                !! See <LINK SRC="diag_manager.html">diag_manager_mod</LINK>
+                                                !! for valid methods.</IN>
+    INTEGER, INTENT(in) :: pack !< Packing method.
+    INTEGER, INTENT(in) :: tile_count !< Tile number.
+    TYPE(coord_type), INTENT(in), OPTIONAL :: local_coord !< Region to be written.
+                                                          !! If missing, then all data to be written.</IN>
+    INTEGER :: out_num, in_num, file_num, file_num_tile1
+    INTEGER :: num_fields, i, method_selected, l1
+    INTEGER :: ioerror
+    REAL :: pow_value
+    INTEGER :: grv !< Value used to determine if the region defined in the diag_table is for the whole axis, or a sub-axis
+    CHARACTER(len=128) :: error_msg
+    CHARACTER(len=50) :: t_method
+    character(len=256) :: tmp_name
+
+    ! Value to use to determine if a region is to be output on the full axis, or sub-axis
+    ! get the value to compare to determine if writing full axis data
+    IF ( region_out_use_alt_value ) THEN
+       grv = GLO_REG_VAL_ALT
+    ELSE
+       grv = GLO_REG_VAL
+    END IF
+
+
+    ! Get a number for this output field
+    num_output_fields = num_output_fields + 1
+    IF ( num_output_fields > max_output_fields ) THEN
+       ! <ERROR STATUS="FATAL">max_output_fields = <max_output_fields> exceeded.  Increase via diag_manager_nml</ERROR>
+       WRITE (UNIT=error_msg,FMT=*) max_output_fields
+       CALL error_mesg('diag_util_mod::init_output_field', 'max_output_fields = '//TRIM(error_msg)//' exceeded.&
+            &  Increase via diag_manager_nml', FATAL)
+    END IF
+    out_num = num_output_fields
+
+    ! First, find the index to the associated input field
+    in_num = find_input_field(module_name, field_name, tile_count)
+    IF ( in_num < 0 ) THEN
+       IF ( tile_count > 1 ) THEN
+          WRITE (error_msg,'(A,"/",A,"/",A)') TRIM(module_name),TRIM(field_name),&
+               & "tile_count="//TRIM(string(tile_count))
+       ELSE
+          WRITE (error_msg,'(A,"/",A)') TRIM(module_name),TRIM(field_name)
+       END IF
+       ! <ERROR STATUS="FATAL">module_name/field_name <module_name>/<field_name>[/tile_count=<tile_count>] NOT registered</ERROR>
+       CALL error_mesg('diag_util_mod::init_output_field',&
+            & 'module_name/field_name '//TRIM(error_msg)//' NOT registered', FATAL)
+    END IF
+
+    ! Add this output field into the list for this input field
+    input_fields(in_num)%num_output_fields =&
+         & input_fields(in_num)%num_output_fields + 1
+    IF ( input_fields(in_num)%num_output_fields > max_out_per_in_field ) THEN
+       ! <ERROR STATUS="FATAL">
+       !   MAX_OUT_PER_IN_FIELD = <MAX_OUT_PER_IN_FIELD> exceeded for <module_name>/<field_name>, increase MAX_OUT_PER_IN_FIELD
+       !   in the diag_manager_nml namelist.
+       ! </ERROR>
+       WRITE (UNIT=error_msg,FMT=*) MAX_OUT_PER_IN_FIELD
+       CALL error_mesg('diag_util_mod::init_output_field',&
+        & 'MAX_OUT_PER_IN_FIELD exceeded for '//TRIM(module_name)//"/"//TRIM(field_name)//&
+        &', increase MAX_OUT_PER_IN_FIELD in the diag_manager_nml namelist', FATAL)
+    END IF
+    input_fields(in_num)%output_fields(input_fields(in_num)%num_output_fields) = out_num
+
+    ! Also put pointer to input field in this output field
+    output_fields(out_num)%input_field = in_num
+
+    ! Next, find the number for the corresponding file
+    IF ( TRIM(output_file).EQ.'null' ) THEN
+       file_num = max_files
+    ELSE
+       file_num = find_file(output_file, 1)
+       IF ( file_num < 0 ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   file <file_name> is NOT found in the diag_table.
+          ! </ERROR>
+          CALL error_mesg('diag_util_mod::init_output_field', 'file '&
+               & //TRIM(output_file)//' is NOT found in the diag_table', FATAL)
+       END IF
+       IF ( tile_count > 1 ) THEN
+          file_num_tile1 = file_num
+          file_num = find_file(output_file, tile_count)
+          IF(file_num < 0) THEN
+             CALL init_file(files(file_num_tile1)%name, files(file_num_tile1)%output_freq,&
+                  & files(file_num_tile1)%output_units, files(file_num_tile1)%format,&
+                  & files(file_num_tile1)%time_units, files(file_num_tile1)%long_name,&
+                  & tile_count, files(file_num_tile1)%new_file_freq,&
+                  & files(file_num_tile1)%new_file_freq_units, files(file_num_tile1)%start_time,&
+                  & files(file_num_tile1)%duration, files(file_num_tile1)%duration_units  )
+             file_num = find_file(output_file, tile_count)
+             IF ( file_num < 0 ) THEN
+                ! <ERROR STATUS="FATAL">
+                !   file <output_file> is not initialized for tile_count = <tile_count>
+                ! </ERROR>
+                CALL error_mesg('diag_util_mod::init_output_field', 'file '//TRIM(output_file)//&
+                     & ' is not initialized for tile_count = '//TRIM(string(tile_count)), FATAL)
+             END IF
+          END IF
+       END IF
+    END IF
+
+    ! Insert this field into list for this file
+    files(file_num)%num_fields = files(file_num)%num_fields + 1
+    IF ( files(file_num)%num_fields > MAX_FIELDS_PER_FILE ) THEN
+       WRITE (UNIT=error_msg, FMT=*) MAX_FIELDS_PER_FILE
+       ! <ERROR STATUS="FATAL">
+       !   MAX_FIELDS_PER_FILE = <MAX_FIELDS_PER_FILE> exceeded.  Increase MAX_FIELDS_PER_FILE in diag_data.F90.
+       ! </ERROR>
+       CALL error_mesg('diag_util_mod::init_output_field',&
+            & 'MAX_FIELDS_PER_FILE = '//TRIM(error_msg)//' exceeded.  Increase MAX_FIELDS_PER_FILE in diag_data.F90.', FATAL)
+    END IF
+    num_fields = files(file_num)%num_fields
+    files(file_num)%fields(num_fields) = out_num
+
+    ! Set the file for this output field
+    output_fields(out_num)%output_file = file_num
+
+    ! Enter the other data for this output field
+    output_fields(out_num)%output_name = TRIM(output_name)
+    output_fields(out_num)%pack = pack
+    output_fields(out_num)%pow_value = 1
+    output_fields(out_num)%num_axes = 0
+    output_fields(out_num)%total_elements = 0
+    output_fields(out_num)%region_elements = 0
+    output_fields(out_num)%imax = 0
+    output_fields(out_num)%jmax = 0
+    output_fields(out_num)%kmax = 0
+    output_fields(out_num)%imin = VERY_LARGE_AXIS_LENGTH
+    output_fields(out_num)%jmin = VERY_LARGE_AXIS_LENGTH
+    output_fields(out_num)%kmin = VERY_LARGE_AXIS_LENGTH
+
+    ! initialize the size of the diurnal axis to 1
+    output_fields(out_num)%n_diurnal_samples = 1
+
+    ! Initialize all time method to false
+    method_selected = 0
+    output_fields(out_num)%time_average = .FALSE.
+    output_fields(out_num)%time_rms = .FALSE.
+    output_fields(out_num)%time_min = .FALSE.
+    output_fields(out_num)%time_max = .FALSE.
+    output_fields(out_num)%time_sum = .FALSE.
+    output_fields(out_num)%time_ops = .FALSE.
+    output_fields(out_num)%written_once = .FALSE.
+
+    t_method = lowercase(time_method)
+    ! cannot time average fields output every time
+    IF ( files(file_num)%output_freq == EVERY_TIME ) THEN
+       output_fields(out_num)%time_average = .FALSE.
+       method_selected = method_selected+1
+       t_method = 'point'
+    ELSEIF ( INDEX(t_method,'diurnal') == 1 ) THEN
+       ! get the integer number from the t_method
+       READ (UNIT=t_method(8:LEN_TRIM(t_method)), FMT=*, IOSTAT=ioerror) output_fields(out_num)%n_diurnal_samples
+       IF ( ioerror /= 0 ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   could not find integer number of diurnal samples in string "<t_method>"
+          ! </ERROR>
+          CALL error_mesg('diag_util_mod::init_output_field',&
+               & 'could not find integer number of diurnal samples in string "' //TRIM(t_method)//'"', FATAL)
+       ELSE IF ( output_fields(out_num)%n_diurnal_samples <= 0 ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   The integer value of diurnal samples must be greater than zero.
+          ! </ERROR>
+          CALL error_mesg('diag_util_mod::init_output_field',&
+               & 'The integer value of diurnal samples must be greater than zero.', FATAL)
+       END IF
+       output_fields(out_num)%time_average = .TRUE.
+       method_selected = method_selected+1
+       t_method='mean'
+    ELSEIF ( INDEX(t_method,'pow') == 1 ) THEN
+       ! Get the integer number from the t_method
+       READ (UNIT=t_method(4:LEN_TRIM(t_method)), FMT=*, IOSTAT=ioerror) pow_value
+       IF ( ioerror /= 0 .OR. output_fields(out_num)%pow_value < 1  .OR. FLOOR(pow_value) /= CEILING(pow_value) ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   Invalid power number in time operation "<t_method>".  Must be a positive integer.
+          ! </ERROR>
+          CALL error_mesg('diag_util_mod::init_output_field',&
+               & 'Invalid power number in time operation "'//TRIM(t_method)//'".  Must be a positive integer', FATAL)
+       END IF
+       output_fields(out_num)%pow_value = INT(pow_value)
+       output_fields(out_num)%time_average = .TRUE.
+       method_selected = method_selected+1
+       t_method = 'mean_pow('//t_method(4:LEN_TRIM(t_method))//')'
+    ELSE
+       SELECT CASE(TRIM(t_method))
+       CASE ( '.true.', 'mean', 'average', 'avg' )
+          output_fields(out_num)%time_average = .TRUE.
+          method_selected = method_selected+1
+          t_method = 'mean'
+       CASE ( 'rms' )
+          output_fields(out_num)%time_average = .TRUE.
+          output_fields(out_num)%time_rms = .TRUE.
+          output_fields(out_num)%pow_value = 2.0
+          method_selected = method_selected+1
+          t_method = 'root_mean_square'
+       CASE ( '.false.', 'none', 'point' )
+          output_fields(out_num)%time_average = .FALSE.
+          method_selected = method_selected+1
+          t_method = 'point'
+       CASE ( 'maximum', 'max' )
+          output_fields(out_num)%time_max = .TRUE.
+          l1 = LEN_TRIM(output_fields(out_num)%output_name)
+          if (l1 .ge. 3) then
+              tmp_name = trim(adjustl(output_fields(out_num)%output_name(l1-2:l1)))
+              IF (lowercase(trim(tmp_name)) /= 'max' ) then
+                  output_fields(out_num)%output_name = TRIM(output_name)//'_max'
+               endif
+          endif
+          method_selected = method_selected+1
+          t_method = 'max'
+       CASE ( 'minimum', 'min' )
+          output_fields(out_num)%time_min = .TRUE.
+          l1 = LEN_TRIM(output_fields(out_num)%output_name)
+          if (l1 .ge. 3) then
+              tmp_name = trim(adjustl(output_fields(out_num)%output_name(l1-2:l1)))
+              IF (lowercase(trim(tmp_name)) /= 'min' ) then
+                  output_fields(out_num)%output_name = TRIM(output_name)//'_min'
+              endif
+          endif
+          method_selected = method_selected+1
+          t_method = 'min'
+       CASE ( 'sum', 'cumsum' )
+          output_fields(out_num)%time_sum = .TRUE.
+          l1 = LEN_TRIM(output_fields(out_num)%output_name)
+          IF ( output_fields(out_num)%output_name(l1-2:l1) /= 'sum' )&
+               & output_fields(out_num)%output_name = TRIM(output_name)//'_sum'
+          method_selected = method_selected+1
+          t_method = 'sum'
+       END SELECT
+    END IF
+
+    ! reconcile logical flags
+    output_fields(out_num)%time_ops = output_fields(out_num)%time_min.OR.output_fields(out_num)%time_max&
+         & .OR.output_fields(out_num)%time_average .OR. output_fields(out_num)%time_sum
+
+    output_fields(out_num)%phys_window = .FALSE.
+    ! need to initialize grid_type = -1(start, end, l_start_indx,l_end_indx etc...)
+    IF ( PRESENT(local_coord) ) THEN
+       input_fields(in_num)%local = .TRUE.
+       input_fields(in_num)%local_coord = local_coord
+       IF ( INT(local_coord%xbegin) ==  grv .AND. INT(local_coord%xend) == grv .AND.&
+            & INT(local_coord%ybegin) == grv .AND. INT(local_coord%yend) == grv ) THEN
+          output_fields(out_num)%local_output = .FALSE.
+          output_fields(out_num)%need_compute = .FALSE.
+          output_fields(out_num)%reduced_k_range = .TRUE.
+       ELSE
+          output_fields(out_num)%local_output = .TRUE.
+          output_fields(out_num)%need_compute = .FALSE.
+          output_fields(out_num)%reduced_k_range = .FALSE.
+       END IF
+
+       output_fields(out_num)%output_grid%start(1) = local_coord%xbegin
+       output_fields(out_num)%output_grid%start(2) = local_coord%ybegin
+       output_fields(out_num)%output_grid%start(3) = local_coord%zbegin
+       output_fields(out_num)%output_grid%end(1) = local_coord%xend
+       output_fields(out_num)%output_grid%end(2) = local_coord%yend
+       output_fields(out_num)%output_grid%end(3) = local_coord%zend
+       DO i = 1, 3
+          output_fields(out_num)%output_grid%l_start_indx(i) = -1
+          output_fields(out_num)%output_grid%l_end_indx(i) = -1
+          output_fields(out_num)%output_grid%subaxes(i) = -1
+       END DO
+    ELSE
+       output_fields(out_num)%local_output = .FALSE.
+       output_fields(out_num)%need_compute = .FALSE.
+       output_fields(out_num)%reduced_k_range = .FALSE.
+    END IF
+
+    ! <ERROR STATUS="FATAL">
+    !   improper time method in diag_table for output field <output_name>
+    ! </ERROR>
+    IF ( method_selected /= 1 ) CALL error_mesg('diag_util_mod::init_output_field',&
+         &'improper time method in diag_table for output field:'//TRIM(output_name),FATAL)
+
+    output_fields(out_num)%time_method = TRIM(t_method)
+
+    ! allocate counters: NOTE that for simplicity we always allocate them, even
+    ! if they are superceeded by 4D "counter" array. This isn't most memory
+    ! efficient, approach, but probably tolerable since they are so small anyway
+    ALLOCATE(output_fields(out_num)%count_0d(output_fields(out_num)%n_diurnal_samples))
+    ALLOCATE(output_fields(out_num)%num_elements(output_fields(out_num)%n_diurnal_samples))
+    output_fields(out_num)%count_0d(:) = 0
+    output_fields(out_num)%num_elements(:) = 0
+    output_fields(out_num)%num_attributes = 0
+  END SUBROUTINE init_output_field
+
+  !> @brief Open file for output, and write the meta data.
+  SUBROUTINE opening_file(file, time, filename_time)
+    ! WARNING: Assumes that all data structures are fully initialized
+    INTEGER, INTENT(in) :: file !< File ID.
+    TYPE(time_type), INTENT(in) :: time !< Time for the file time stamp
+    TYPE(time_type), INTENT(in), optional :: filename_time !< Time used in setting the filename when writting periodic files
+
+    TYPE(time_type) :: fname_time !< Time used in setting the filename when writting periodic files
+    REAL, DIMENSION(2) :: DATA
+    INTEGER :: j, field_num, input_field_num, num_axes, k
+    INTEGER :: field_num1
+    INTEGER :: position
+    INTEGER :: dir, edges
+    INTEGER :: ntileMe
+    INTEGER :: year, month, day, hour, minute, second
+    INTEGER, ALLOCATABLE :: tile_id(:)
+    INTEGER, DIMENSION(1) :: time_axis_id, time_bounds_id
+    ! size of this axes array must be at least max num. of
+    ! axes per field + 2; the last two elements are for time
+    ! and time bounds dimensions
+    INTEGER, DIMENSION(6) :: axes
+    INTEGER, ALLOCATABLE  :: axesc(:) ! indices if compressed axes associated with the field
+    LOGICAL :: time_ops, aux_present, match_aux_name, req_present, match_req_fields
+    LOGICAL :: all_scalar_or_1d
+    CHARACTER(len=7) :: prefix
+    CHARACTER(len=7) :: avg_name = 'average'
+    CHARACTER(len=128) :: time_units, timeb_units, avg, error_string, filename, aux_name, req_fields, fieldname
+    CHARACTER(len=128) :: suffix, base_name
+    CHARACTER(len=32) :: time_name, timeb_name,time_longname, timeb_longname, cart_name
+    CHARACTER(len=256) :: fname
+    CHARACTER(len=24) :: start_date
+    TYPE(domain1d) :: domain
+    TYPE(domain2d) :: domain2
+    TYPE(domainUG) :: domainU
+    INTEGER :: is, ie, last, ind
+    character(len=2) :: fnum_domain
+    class(FmsNetcdfFile_t), pointer    :: fileob
+    INTEGER :: calendar
+    INTEGER :: time_bounds_num_attributes
+    TYPE(diag_atttype), allocatable :: time_bounds_attributes(:)
+
+    aux_present = .FALSE.
+    match_aux_name = .FALSE.
+    req_present = .FALSE.
+    match_req_fields = .FALSE.
+
+    ! Here is where time_units string must be set up; time since base date
+    WRITE (time_units, 11) TRIM(time_unit_list(files(file)%time_units)), base_year,&
+         & base_month, base_day, base_hour, base_minute, base_second
+11  FORMAT(A, ' since ', I4.4, '-', I2.2, '-', I2.2, ' ', I2.2, ':', I2.2, ':', I2.2)
+    base_name = files(file)%name
+    IF ( files(file)%new_file_freq < VERY_LARGE_FILE_FREQ ) THEN
+       position = INDEX(files(file)%name, '%')
+       IF ( position > 0 )  THEN
+          base_name = base_name(1:position-1)
+       ELSE
+          ! <ERROR STATUS="FATAL">
+          !   filename <files(file)%name> does not contain % for time stamp string
+          ! </ERROR>
+          CALL error_mesg('diag_util_mod::opening_file',&
+               & 'file name '//TRIM(files(file)%name)//' does not contain % for time stamp string', FATAL)
+       END IF
+       if (present(filename_time)) then
+          fname_time = filename_time
+       else
+          fname_time = time
+       endif
+       suffix = get_time_string(files(file)%name, fname_time)
+    ELSE
+       suffix = ' '
+    END IF
+
+    ! Add ensemble ID to filename
+    fname=base_name
+    call fms2_io_get_instance_filename(fname, base_name)
+
+    ! Set the filename
+    filename = TRIM(base_name)//TRIM(suffix)
+
+    ! prepend the file start date if prepend_date == .TRUE.
+    IF ( prepend_date ) THEN
+       call get_date(diag_init_time, year, month, day, hour, minute, second)
+       write (start_date, '(1I20.4, 2I2.2)') year, month, day
+
+       filename = TRIM(adjustl(start_date))//'.'//TRIM(filename)
+    END IF
+
+    ! Loop through all fields with this file to output axes
+    ! JWD: This is a klooge; need something more robust
+    domain2 = NULL_DOMAIN2D
+    domainU = NULL_DOMAINUG
+    all_scalar_or_1d = .TRUE.
+    DO j = 1, files(file)%num_fields
+       field_num = files(file)%fields(j)
+       if (output_fields(field_num)%local_output .AND. .NOT. output_fields(field_num)%need_compute) CYCLE
+       num_axes = output_fields(field_num)%num_axes
+       IF ( num_axes > 1 ) THEN
+          all_scalar_or_1d = .FALSE.
+          domain2 = get_domain2d ( output_fields(field_num)%axes(1:num_axes) )
+          domainU = get_domainUG ( output_fields(field_num)%axes(1) )
+          IF ( domain2 .NE. NULL_DOMAIN2D ) EXIT
+       ELSEIF (num_axes == 1) THEN
+          if (domainU .EQ. null_domainUG) then
+               domainU = get_domainUG ( output_fields(field_num)%axes(num_axes) )
+          endif
+       END IF
+    END DO
+
+    IF (.NOT. all_scalar_or_1d) THEN
+        IF (domainU .NE. null_domainUG .AND. domain2 .NE. null_domain2D) THEN
+            CALL error_mesg('diag_util_mod::opening_file', &
+                            'Domain2 and DomainU are somehow both set.', &
+                            FATAL)
+        ELSEIF (domainU .EQ. null_domainUG) THEN
+            IF (domain2 .EQ. NULL_DOMAIN2D) THEN
+                CALL return_domain(domain2)
+            ENDIF
+
+            IF (domain2 .EQ. NULL_DOMAIN2D) THEN
+
+                !Fix for the corner-case when you have a file that contains
+                !2D field(s) that is not associated with a domain tile, as
+                !is usually assumed.
+
+                !This is very confusing, but I will try to explain.  The
+                !all_scalar_or_1d flag determines if the file name is associated
+                !with a domain (i.e. has ".tilex." in the file name).  A value
+                !of .FALSE. for the all_scalar_or_1d flag signals that the
+                !file name is associated with a domain tile.  Normally,
+                !files that contain at least one two-dimensional field are
+                !assumed to be associated with a specific domain tile, and
+                !thus have the value of the all_scalar_or_1d flag set to
+                !.FALSE.  It is possible, however, to have a file that contains
+                !two-dimensional fields that is not associated with a domain tile
+                !(i.e., if you make it into this branch.).  If that is the
+                !case, then reset the all_scalar_or_1d flag back to .TRUE.
+                !Got that?
+                all_scalar_or_1d = .TRUE.
+
+            ELSE
+                ntileMe = mpp_get_current_ntile(domain2)
+                ALLOCATE(tile_id(ntileMe))
+                tile_id = mpp_get_tile_id(domain2)
+                fname = TRIM(filename)
+                IF ( mpp_get_ntile_count(domain2) > 1 ) THEN
+                   CALL get_tile_string(filename, TRIM(fname)//'.tile' , tile_id(files(file)%tile_count))
+                ELSEIF ( tile_id(1) > 1 ) then
+                   CALL get_tile_string(filename, TRIM(fname)//'.tile' , tile_id(1))
+                ENDIF
+                DEALLOCATE(tile_id)
+            ENDIF
+        ENDIF
+    ENDIF
+    IF ( domainU .ne. null_domainUG) then
+          fname = TRIM(filename)
+          CALL get_mosaic_tile_file_ug(fname,filename,domainU)
+    ENDIF
+    IF ( allocated(files(file)%attributes) ) THEN
+                CALL diag_output_init(filename, files(file)%format, global_descriptor,&
+                & files(file)%file_unit, all_scalar_or_1d, domain2, domainU,&
+                & fileobj(file),fileobjU(file), fileobjND(file), fnum_for_domain(file),&
+                & attributes=files(file)%attributes(1:files(file)%num_attributes))
+    ELSE
+                CALL diag_output_init(filename, files(file)%format, global_descriptor,&
+                & files(file)%file_unit, all_scalar_or_1d, domain2,domainU, &
+                & fileobj(file),fileobjU(file),fileobjND(file),fnum_for_domain(file))
+    END IF
+    !> update fnum_for_domain with the correct domain
+    files(file)%bytes_written = 0
+    ! Does this file contain time_average fields?
+    time_ops = .FALSE.
+    DO j = 1, files(file)%num_fields
+       field_num = files(file)%fields(j)
+       IF ( output_fields(field_num)%time_ops ) THEN
+          time_ops = .TRUE.
+          EXIT
+       END IF
+    END DO
+    ! Loop through all fields with this file to output axes
+    DO j = 1, files(file)%num_fields
+       field_num = files(file)%fields(j)
+       input_field_num = output_fields(field_num)%input_field
+       IF (.NOT.input_fields(input_field_num)%register) THEN
+          WRITE (error_string,'(A,"/",A)') TRIM(input_fields(input_field_num)%module_name),&
+               & TRIM(input_fields(input_field_num)%field_name)
+          IF(mpp_pe() .EQ. mpp_root_pe()) THEN
+             ! <ERROR STATUS="WARNING">
+             !   module/field_name (<input_fields(input_field_num)%module_name>/<input_fields(input_field_num)%field_name>)
+             !   NOT registered
+             ! </ERROR>
+             CALL error_mesg('diag_util_mod::opening_file',&
+                  & 'module/field_name ('//TRIM(error_string)//') NOT registered', WARNING)
+          END IF
+          CYCLE
+       END IF
+       if (output_fields(field_num)%local_output .AND. .NOT. output_fields(field_num)%need_compute) CYCLE
+
+       ! Put the time axis in the axis field
+       num_axes = output_fields(field_num)%num_axes
+       axes(1:num_axes) = output_fields(field_num)%axes(1:num_axes)
+       ! make sure that axis_id are not -1
+       DO k = 1, num_axes
+          IF ( axes(k) < 0 ) THEN
+             WRITE(error_string,'(a)') output_fields(field_num)%output_name
+             ! <ERROR STATUS="FATAL">
+             !   ouptut_name <output_fields(field_num)%output_name> has axis_id = -1
+             ! </ERROR>
+             CALL error_mesg('diag_util_mod::opening_file','output_name '//TRIM(error_string)//&
+                  & ' has axis_id = -1', FATAL)
+          END IF
+       END DO
+       ! check if aux is present in any axes
+       IF ( .NOT.aux_present ) THEN
+          DO k = 1, num_axes
+             aux_name = get_axis_aux(axes(k))
+             IF ( TRIM(aux_name) /= 'none' ) THEN
+                aux_present = .TRUE.
+                EXIT
+             END IF
+          END DO
+       END IF
+       ! check if required fields are present in any axes
+       IF ( .NOT.req_present ) THEN
+          DO k = 1, num_axes
+             req_fields = get_axis_reqfld(axes(k))
+             IF ( TRIM(req_fields) /= 'none' ) THEN
+                CALL error_mesg('diag_util_mod::opening_file','required fields found: '//&
+                               &TRIM(req_fields)//' in file '//TRIM(files(file)%name),NOTE)
+                req_present = .TRUE.
+                EXIT
+             END IF
+          END DO
+       END IF
+
+       axes(num_axes + 1) = files(file)%time_axis_id
+!> Allocate the is_time_axis_registered field and set it to false for the first trip
+       if (.not. allocated(files(file)%is_time_axis_registered)) then
+          allocate(files(file)%is_time_axis_registered)
+          files(file)%is_time_axis_registered = .false.
+       endif
+       if (fnum_for_domain(file) == "2d") then
+          CALL write_axis_meta_data(files(file)%file_unit, axes(1:num_axes + 1),fileobj(file), time_ops=time_ops, &
+                                   time_axis_registered=files(file)%is_time_axis_registered)
+       elseif (fnum_for_domain(file) == "nd") then
+          CALL write_axis_meta_data(files(file)%file_unit, axes(1:num_axes + 1),fileobjnd(file), time_ops=time_ops, &
+                                   time_axis_registered=files(file)%is_time_axis_registered)
+       elseif (fnum_for_domain(file) == "ug") then
+          CALL write_axis_meta_data(files(file)%file_unit, axes(1:num_axes + 1),fileobjU(file), time_ops=time_ops, &
+                                   time_axis_registered=files(file)%is_time_axis_registered)
+       endif
+       IF ( time_ops ) THEN
+          axes(num_axes + 2) = files(file)%time_bounds_id
+          if (fnum_for_domain(file) == "2d") then
+              CALL write_axis_meta_data(files(file)%file_unit, axes(1:num_axes + 2),fileobj(file), &
+                                   time_axis_registered=files(file)%is_time_axis_registered)
+       elseif (fnum_for_domain(file) == "nd") then
+              CALL write_axis_meta_data(files(file)%file_unit, axes(1:num_axes + 2),fileobjND(file), &
+                                   time_axis_registered=files(file)%is_time_axis_registered)
+          elseif (fnum_for_domain(file) == "ug") then
+              CALL write_axis_meta_data(files(file)%file_unit, axes(1:num_axes + 2),fileobjU(file), &
+                                   time_axis_registered=files(file)%is_time_axis_registered)
+          endif
+       END IF
+       ! write metadata for axes used  in compression-by-gathering, e.g. for unstructured
+       ! grid
+       DO k = 1, num_axes
+          IF (axis_is_compressed(axes(k))) THEN
+             CALL get_compressed_axes_ids(axes(k), axesc) ! returns allocatable array
+             if (fnum_for_domain(file) == "2d" ) then
+                 CALL write_axis_meta_data(files(file)%file_unit, axesc,fileobj(file), &
+                                   time_axis_registered=files(file)%is_time_axis_registered)
+             elseif (fnum_for_domain(file) == "nd") then
+                 CALL write_axis_meta_data(files(file)%file_unit, axesc,fileobjND(file), &
+                                   time_axis_registered=files(file)%is_time_axis_registered)
+             elseif (fnum_for_domain(file) == "ug") then
+                 CALL write_axis_meta_data(files(file)%file_unit, axesc,fileobjU(file), &
+                                   time_axis_registered=files(file)%is_time_axis_registered)
+             endif
+             DEALLOCATE(axesc)
+          ENDIF
+       ENDDO
+    END DO
+
+    ! Looking for the first NON-static field in a file
+    field_num1 = files(file)%fields(1)
+    DO j = 1, files(file)%num_fields
+       field_num = files(file)%fields(j)
+       IF ( output_fields(field_num)%time_ops ) THEN
+          field_num1 = field_num
+          EXIT
+       END IF
+    END DO
+    nfields_loop: DO j = 1, files(file)%num_fields
+       field_num = files(file)%fields(j)
+       input_field_num = output_fields(field_num)%input_field
+       IF (.NOT.input_fields(input_field_num)%register) CYCLE
+       IF (output_fields(field_num)%local_output .AND. .NOT. output_fields(field_num)%need_compute) CYCLE
+       ! Make sure that 1 file contains either time_average or instantaneous fields
+       ! cannot have both time_average and instantaneous in 1 file
+       IF ( .NOT.mix_snapshot_average_fields ) THEN
+          IF ( (output_fields(field_num)%time_ops.NEQV.output_fields(field_num1)%time_ops) .AND.&
+               & .NOT.output_fields(field_num1)%static .AND. .NOT.output_fields(field_num)%static) THEN
+             IF ( mpp_pe() == mpp_root_pe() ) THEN
+                ! <ERROR STATUS="FATAL">
+                !   <files(file)%name> can NOT have BOTH time average AND instantaneous fields.
+                !   Create a new file or set mix_snapshot_average_fields=.TRUE. in the namelist diag_manager_nml.
+                ! </ERROR>
+                CALL error_mesg('diag_util_mod::opening_file','file '//&
+                     & TRIM(files(file)%name)//' can NOT have BOTH time average AND instantaneous fields.'//&
+                     & ' Create a new file or set mix_snapshot_average_fields=.TRUE. in the namelist diag_manager_nml.' , FATAL)
+             END IF
+          END IF
+       END IF
+       ! check if any field has the same name as aux_name
+       IF ( aux_present .AND. .NOT.match_aux_name ) THEN
+          fieldname = output_fields(field_num)%output_name
+          IF ( INDEX(aux_name, TRIM(fieldname)) > 0 ) match_aux_name = .TRUE.
+       END IF
+       ! check if any field has the same name as req_fields
+       IF ( req_present .AND. .NOT.match_req_fields ) THEN
+          fieldname = output_fields(field_num)%output_name
+          is = 1; last = len_trim(req_fields)
+          DO
+            ind = index(req_fields(is:last),' ')
+            IF (ind .eq. 0) ind = last-is+2
+            ie = is+(ind-2)
+            if (req_fields(is:ie) .EQ. trim(fieldname)) then
+              match_req_fields = .TRUE.
+             !CALL error_mesg('diag_util_mod::opening_file','matched required field: '//TRIM(fieldname),NOTE)
+              EXIT
+            END IF
+            is = is+ind
+            if (is .GT. last) EXIT
+          END DO
+       END IF
+
+       ! Put the time axis in the axis field
+       num_axes = output_fields(field_num)%num_axes
+       axes(1:num_axes) = output_fields(field_num)%axes(1:num_axes)
+       IF ( .NOT.output_fields(field_num)%static ) THEN
+          num_axes=num_axes+1
+          axes(num_axes) = files(file)%time_axis_id
+       END IF
+       IF(output_fields(field_num)%time_average) THEN
+          avg = avg_name
+       ELSE IF(output_fields(field_num)%time_max) THEN
+          avg = avg_name
+       ELSE IF(output_fields(field_num)%time_min) THEN
+          avg = avg_name
+       ELSE
+          avg = " "
+       END IF
+!> Use the correct file object
+       if (fnum_for_domain(file) == "2d") then
+          fileob => fileobj (file)
+       elseif (fnum_for_domain(file) == "nd") then
+          fileob => fileobjND(file)
+       elseif (fnum_for_domain(file) == "ug") then
+          fileob => fileobjU(file)
+       endif
+       IF ( input_fields(input_field_num)%missing_value_present ) THEN
+          IF ( LEN_TRIM(input_fields(input_field_num)%interp_method) > 0 ) THEN
+             output_fields(field_num)%f_type = write_field_meta_data(files(file)%file_unit,&
+                  & output_fields(field_num)%output_name, axes(1:num_axes),&
+                  & input_fields(input_field_num)%units,&
+                  & input_fields(input_field_num)%long_name,&
+                  & input_fields(input_field_num)%range, output_fields(field_num)%pack,&
+                  & input_fields(input_field_num)%missing_value, avg_name = avg,&
+                  & time_method=output_fields(field_num)%time_method,&
+                  & standard_name = input_fields(input_field_num)%standard_name,&
+                  & interp_method = input_fields(input_field_num)%interp_method,&
+                  & attributes=output_fields(field_num)%attributes,&
+                  & num_attributes=output_fields(field_num)%num_attributes,&
+                  & use_UGdomain=files(file)%use_domainUG , &
+                  & fileob=fileob)
+          ELSE
+             output_fields(field_num)%f_type = write_field_meta_data(files(file)%file_unit,&
+                  & output_fields(field_num)%output_name, axes(1:num_axes),&
+                  & input_fields(input_field_num)%units,&
+                  & input_fields(input_field_num)%long_name,&
+                  & input_fields(input_field_num)%range, output_fields(field_num)%pack,&
+                  & input_fields(input_field_num)%missing_value, avg_name = avg,&
+                  & time_method=output_fields(field_num)%time_method,&
+                  & standard_name = input_fields(input_field_num)%standard_name,&
+                  & attributes=output_fields(field_num)%attributes,&
+                  & num_attributes=output_fields(field_num)%num_attributes,&
+                  & use_UGdomain=files(file)%use_domainUG , &
+                  & fileob=fileob)
+
+          END IF
+          ! NEED TO TAKE CARE OF TIME AVERAGING INFO TOO BOTH CASES
+       ELSE
+          IF ( LEN_TRIM(input_fields(input_field_num)%interp_method) > 0 ) THEN
+             output_fields(field_num)%f_type = write_field_meta_data(files(file)%file_unit,&
+                  & output_fields(field_num)%output_name, axes(1:num_axes),&
+                  & input_fields(input_field_num)%units,&
+                  & input_fields(input_field_num)%long_name,&
+                  & input_fields(input_field_num)%range, output_fields(field_num)%pack,&
+                  & avg_name = avg,&
+                  & time_method=output_fields(field_num)%time_method,&
+                  & standard_name = input_fields(input_field_num)%standard_name,&
+                  & interp_method = input_fields(input_field_num)%interp_method,&
+                  & attributes=output_fields(field_num)%attributes,&
+                  & num_attributes=output_fields(field_num)%num_attributes,&
+                  & use_UGdomain=files(file)%use_domainUG , &
+                  & fileob=fileob)
+
+          ELSE
+             output_fields(field_num)%f_type = write_field_meta_data(files(file)%file_unit,&
+                  & output_fields(field_num)%output_name, axes(1:num_axes),&
+                  & input_fields(input_field_num)%units,&
+                  & input_fields(input_field_num)%long_name,&
+                  & input_fields(input_field_num)%range, output_fields(field_num)%pack,&
+                  & avg_name = avg,&
+                  & time_method=output_fields(field_num)%time_method,&
+                  & standard_name = input_fields(input_field_num)%standard_name,&
+                  & attributes=output_fields(field_num)%attributes,&
+                  & num_attributes=output_fields(field_num)%num_attributes,&
+                  & use_UGdomain=files(file)%use_domainUG , &
+                  & fileob=fileob)
+
+          END IF
+       END IF
+    END DO nfields_loop
+    ! If any of the fields in the file are time averaged, need to output the axes
+    ! Use double precision since time axis is double precision
+    IF ( time_ops ) THEN
+       time_axis_id(1) = files(file)%time_axis_id
+       files(file)%f_avg_start = write_field_meta_data(files(file)%file_unit,&
+            & avg_name // '_T1', time_axis_id, time_units,&
+            & "Start time for average period", pack=pack_size , &
+            & fileob=fileob)
+       files(file)%f_avg_end = write_field_meta_data(files(file)%file_unit,&
+            & avg_name // '_T2', time_axis_id, time_units,&
+            & "End time for average period", pack=pack_size , &
+            & fileob=fileob)
+       files(file)%f_avg_nitems = write_field_meta_data(files(file)%file_unit,&
+            & avg_name // '_DT', time_axis_id,&
+            & TRIM(time_unit_list(files(file)%time_units)),&
+            & "Length of average period", pack=pack_size , &
+            & fileob=fileob)
+    END IF
+
+    IF ( time_ops ) THEN
+       time_axis_id(1) = files(file)%time_axis_id
+       time_bounds_id(1) = files(file)%time_bounds_id
+       CALL get_diag_axis( time_axis_id(1), time_name, time_units, time_longname,&
+            & cart_name, dir, edges, Domain, domainU, DATA)
+       CALL get_diag_axis( time_bounds_id(1), timeb_name, timeb_units, timeb_longname,&
+            & cart_name, dir, edges, Domain, domainU, DATA)
+       calendar = get_calendar_type()
+       time_bounds_num_attributes = 1
+       allocate(time_bounds_attributes(1))
+       time_bounds_attributes(1)%type = NF90_CHAR
+       time_bounds_attributes(1)%len = len_trim(valid_calendar_types(calendar)) 
+       time_bounds_attributes(1)%name = 'calendar'
+       time_bounds_attributes(1)%catt = lowercase(TRIM(valid_calendar_types(calendar)))
+       IF ( do_cf_compliance() ) THEN
+          ! CF Compliance requires the unit on the _bounds axis is the same as 'time'
+          files(file)%f_bounds =  write_field_meta_data(files(file)%file_unit,&
+               & TRIM(time_name)//'_bounds', (/time_bounds_id,time_axis_id/),&
+               & time_units, TRIM(time_name)//' interval endpoints', pack=pack_size , &
+               & attributes=time_bounds_attributes, num_attributes=time_bounds_num_attributes, &
+               & fileob=fileob)
+       ELSE
+          files(file)%f_bounds =  write_field_meta_data(files(file)%file_unit,&
+               & TRIM(time_name)//'_bounds', (/time_bounds_id,time_axis_id/),&
+               & TRIM(time_unit_list(files(file)%time_units)),&
+               & TRIM(time_name)//' interval endpoints', pack=pack_size, &
+               & attributes=time_bounds_attributes, num_attributes=time_bounds_num_attributes, &
+               & fileob=fileob)
+       END IF
+    END IF
+    ! Let lower levels know that all meta data has been sent
+    call done_meta_data(files(file)%file_unit)
+
+    IF( aux_present .AND. .NOT.match_aux_name ) THEN
+       ! <ERROR STATUS="WARNING">
+       !   one axis has auxiliary but the corresponding field is NOT
+       !   found in file <file_name>
+       ! </ERROR>
+       IF ( mpp_pe() == mpp_root_pe() ) CALL error_mesg('diag_util_mod::opening_file',&
+            &'one axis has auxiliary but the corresponding field is NOT found in file '//TRIM(files(file)%name), WARNING)
+    END IF
+    IF( req_present .AND. .NOT.match_req_fields ) THEN
+       ! <ERROR STATUS="FATAL">
+       !   one axis has required fields but the corresponding field is NOT
+       !   found in file <file_name>
+       ! </ERROR>
+       IF ( mpp_pe() == mpp_root_pe() ) CALL error_mesg('diag_util_mod::opening_file',&
+                  &'one axis has required fields ('//trim(req_fields)//') but the '// &
+                  &'corresponding fields are NOT found in file '//TRIM(files(file)%name), FATAL)
+    END IF
+    ! Clean up pointer
+    if (associated(fileob)) nullify(fileob)
+  END SUBROUTINE opening_file
+
+  !> @brief This function determines a string based on current time.
+  !!     This string is used as suffix in output file name
+  !! @return Character(len=128) get_time_string
+  CHARACTER(len=128) FUNCTION get_time_string(filename, current_time)
+    CHARACTER(len=128), INTENT(in) :: filename !< File name.
+    TYPE(time_type), INTENT(in) :: current_time !< Current model time.
+
+    INTEGER :: yr1 !< get from current time
+    INTEGER :: mo1 !< get from current time
+    INTEGER :: dy1 !< get from current time
+    INTEGER :: hr1 !< get from current time
+    INTEGER :: mi1 !< get from current time
+    INTEGER :: sc1 !< get from current time
+    INTEGER :: yr2 !< for computing next_level time unit
+    INTEGER :: dy2 !< for computing next_level time unit
+    INTEGER :: hr2 !< for computing next_level time unit
+    INTEGER :: mi2 !< for computing next_level time unit
+    INTEGER :: yr1_s !< actual values to write string
+    INTEGER :: mo1_s !< actual values to write string
+    INTEGER :: dy1_s !< actual values to write string
+    INTEGER :: hr1_s !< actual values to write string
+    INTEGER :: mi1_s !< actual values to write string
+    INTEGER :: sc1_s !< actual values to write string
+    INTEGER :: abs_day              !< component of current_time
+    INTEGER :: abs_sec              !< component of current_time
+    INTEGER :: days_per_month(12) = (/31,28,31,30,31,30,31,31,30,31,30,31/)
+    INTEGER :: julian_day, i, position, len, first_percent
+    CHARACTER(len=1) :: width  !< width of the field in format write
+    CHARACTER(len=10) :: format
+    CHARACTER(len=20) :: yr !< string of current time (output)
+    CHARACTER(len=20) :: mo !< string of current time (output)
+    CHARACTER(len=20) :: dy !< string of current time (output)
+    CHARACTER(len=20) :: hr !< string of current time (output)
+    CHARACTER(len=20) :: mi !< string of current time (output)
+    CHARACTER(len=20) :: sc !< string of current time (output)
+    CHARACTER(len=128) :: filetail
+
+    format = '("-",i*.*)'
+    CALL get_date(current_time, yr1, mo1, dy1, hr1, mi1, sc1)
+    len = LEN_TRIM(filename)
+    first_percent = INDEX(filename, '%')
+    filetail = filename(first_percent:len)
+    ! compute year string
+    position = INDEX(filetail, 'yr')
+    IF ( position > 0 ) THEN
+       width = filetail(position-1:position-1)
+       yr1_s = yr1
+       format(7:9) = width//'.'//width
+       WRITE(yr, format) yr1_s
+       yr2 = 0
+    ELSE
+       yr = ' '
+       yr2 = yr1 - 1
+    END IF
+    ! compute month string
+    position = INDEX(filetail, 'mo')
+    IF ( position > 0 ) THEN
+       width = filetail(position-1:position-1)
+       mo1_s = yr2*12 + mo1
+       format(7:9) = width//'.'//width
+       WRITE(mo, format) mo1_s
+    ELSE
+       mo = ' '
+    END IF
+    ! compute day string
+    IF ( LEN_TRIM(mo) > 0 ) THEN ! month present
+       dy1_s = dy1
+       dy2 = dy1_s - 1
+    ELSE IF ( LEN_TRIM(yr) >0 )  THEN ! no month, year present
+       ! compute julian day
+       IF ( mo1 == 1 ) THEN
+          dy1_s = dy1
+       ELSE
+          julian_day = 0
+          DO i = 1, mo1-1
+             julian_day = julian_day + days_per_month(i)
+          END DO
+          IF ( leap_year(current_time) .AND. mo1 > 2 ) julian_day = julian_day + 1
+          julian_day = julian_day + dy1
+          dy1_s = julian_day
+       END IF
+       dy2 = dy1_s - 1
+    ELSE ! no month, no year
+       CALL get_time(current_time, abs_sec, abs_day)
+       dy1_s = abs_day
+       dy2 = dy1_s
+    END IF
+    position = INDEX(filetail, 'dy')
+    IF ( position > 0 ) THEN
+       width = filetail(position-1:position-1)
+       FORMAT(7:9) = width//'.'//width
+       WRITE(dy, FORMAT) dy1_s
+    ELSE
+       dy = ' '
+    END IF
+    ! compute hour string
+    IF ( LEN_TRIM(dy) > 0 ) THEN
+       hr1_s = hr1
+    ELSE
+       hr1_s = dy2*24 + hr1
+    END IF
+    hr2 = hr1_s
+    position = INDEX(filetail, 'hr')
+    IF ( position > 0 ) THEN
+       width = filetail(position-1:position-1)
+       format(7:9) = width//'.'//width
+       WRITE(hr, format) hr1_s
+    ELSE
+       hr = ' '
+    END IF
+    ! compute minute string
+    IF ( LEN_TRIM(hr) > 0 ) THEN
+       mi1_s = mi1
+    ELSE
+       mi1_s = hr2*60 + mi1
+    END IF
+    mi2 = mi1_s
+    position = INDEX(filetail, 'mi')
+    IF(position>0) THEN
+       width = filetail(position-1:position-1)
+       format(7:9) = width//'.'//width
+       WRITE(mi, format) mi1_s
+    ELSE
+       mi = ' '
+    END IF
+    ! compute second string
+    IF ( LEN_TRIM(mi) > 0 ) THEN
+       sc1_s = sc1
+    ELSE
+       sc1_s = NINT(mi2*SECONDS_PER_MINUTE) + sc1
+    END IF
+    position = INDEX(filetail, 'sc')
+    IF ( position > 0 ) THEN
+       width = filetail(position-1:position-1)
+       format(7:9) = width//'.'//width
+       WRITE(sc, format) sc1_s
+    ELSE
+       sc = ' '
+    ENDIF
+    get_time_string = TRIM(yr)//TRIM(mo)//TRIM(dy)//TRIM(hr)//TRIM(mi)//TRIM(sc)
+    IF ( LEN_TRIM(get_time_string) > 0 ) get_time_string(1:1) = '.'
+  END FUNCTION get_time_string
+
+  !> @brief Return the difference between two times in units.
+  !! @return Real get_data_dif
+  REAL FUNCTION get_date_dif(t2, t1, units)
+    TYPE(time_type), INTENT(in) :: t2 !< Most recent time.
+    TYPE(time_type), INTENT(in) :: t1 !< Most distant time.
+    INTEGER, INTENT(in) :: units !< Unit of return value.
+
+    INTEGER :: dif_seconds, dif_days
+    TYPE(time_type) :: dif_time
+
+    ! Compute time axis label value
+    ! <ERROR STATUS="FATAL">
+    !   variable t2 is less than in variable t1
+    ! </ERROR>
+    IF ( t2 < t1 ) CALL error_mesg('diag_util_mod::get_date_dif', &
+         & 'in variable t2 is less than in variable t1', FATAL)
+
+    dif_time = t2 - t1
+
+    CALL get_time(dif_time, dif_seconds, dif_days)
+
+    IF ( units == DIAG_SECONDS ) THEN
+       get_date_dif = dif_seconds + SECONDS_PER_DAY * dif_days
+    ELSE IF ( units == DIAG_MINUTES ) THEN
+       get_date_dif = 1440 * dif_days + dif_seconds / SECONDS_PER_MINUTE
+    ELSE IF ( units == DIAG_HOURS ) THEN
+       get_date_dif = 24 * dif_days + dif_seconds / SECONDS_PER_HOUR
+    ELSE IF ( units == DIAG_DAYS ) THEN
+       get_date_dif = dif_days + dif_seconds / SECONDS_PER_DAY
+    ELSE IF ( units == DIAG_MONTHS ) THEN
+       ! <ERROR STATUS="FATAL">
+       !   months not supported as output units
+       ! </ERROR>
+       CALL error_mesg('diag_util_mod::get_date_dif', 'months not supported as output units', FATAL)
+    ELSE IF ( units == DIAG_YEARS ) THEN
+       ! <ERROR STATUS="FATAL">
+       !   years not suppored as output units
+       ! </ERROR>
+       CALL error_mesg('diag_util_mod::get_date_dif', 'years not supported as output units', FATAL)
+    ELSE
+       ! <ERROR STATUS="FATAL">
+       !   illegal time units
+       ! </ERROR>
+       CALL error_mesg('diag_util_mod::diag_date_dif', 'illegal time units', FATAL)
+    END IF
+  END FUNCTION get_date_dif
+
+  !> @brief Write data out to file, and if necessary flush the buffers.
+  SUBROUTINE diag_data_out(file, field, dat, time, final_call_in, static_write_in, filename_time)
+    INTEGER, INTENT(in) :: file !< File ID.
+    INTEGER, INTENT(in) :: field !< Field ID.
+    REAL, DIMENSION(:,:,:,:), INTENT(inout) :: dat !< Data to write out.
+    TYPE(time_type), INTENT(in) :: time !< Current model time.
+    LOGICAL, OPTIONAL, INTENT(in):: final_call_in !< <TT>.TRUE.</TT> if this is the last write for file.
+    LOGICAL, OPTIONAL, INTENT(in):: static_write_in !< <TT>.TRUE.</TT> if static fields are to be written to file.
+    type(time_type), intent(in), optional :: filename_time !< Time used in setting the filename when writting periodic files
+
+    LOGICAL :: final_call, do_write, static_write
+    INTEGER :: i, num
+    REAL :: dif, time_data(2, 1, 1, 1), dt_time(1, 1, 1, 1), start_dif, end_dif
+
+    do_write = .TRUE.
+    final_call = .FALSE.
+    IF ( PRESENT(final_call_in) ) final_call = final_call_in
+    static_write = .FALSE.
+    IF ( PRESENT(static_write_in) ) static_write = static_write_in
+!> dif is the time as a real that is evaluated
+    dif = get_date_dif(time, base_time, files(file)%time_units)
+
+    ! get file_unit, open new file and close curent file if necessary
+    IF ( .NOT.static_write .OR. files(file)%file_unit < 0 ) &
+       CALL check_and_open(file, time, do_write, filename_time=filename_time)
+    IF ( .NOT.do_write ) RETURN  ! no need to write data
+!> Set up the time index and write the correct time value to the time array
+    if (dif > files(file)%rtime_current) then
+     files(file)%time_index = files(file)%time_index + 1
+     files(file)%rtime_current = dif
+     if (fnum_for_domain(file) == "2d") then
+          call diag_write_time (fileobj(file), files(file)%rtime_current, files(file)%time_index,   &
+                                time_name=fileobj(file)%time_name)
+     elseif (fnum_for_domain(file) == "ug") then
+          call diag_write_time (fileobjU(file), files(file)%rtime_current, files(file)%time_index,  &
+                                time_name=fileobjU(file)%time_name)
+     elseif (fnum_for_domain(file) == "nd") then
+          call diag_write_time (fileobjND(file), files(file)%rtime_current, files(file)%time_index, &
+                                time_name=fileobjND(file)%time_name)
+     else
+          call error_mesg("diag_util_mod::diag_data_out","Error opening the file "//files(file)%name,fatal)
+     endif
+    elseif (dif < files(file)%rtime_current .and. .not.(static_write) ) then
+     call error_mesg("diag_util_mod::diag_data_out","The time for the file "//trim(files(file)%name)//&
+                    " has gone backwards. There may be missing values for some of the variables",NOTE)
+    endif
+!> Write data
+    call diag_field_write (output_fields(field)%output_name, dat, static=static_write, file_num=file, fileobjU=fileobjU, &
+                         fileobj=fileobj, fileobjND=fileobjND, fnum_for_domain=fnum_for_domain(file), time_in=files(file)%time_index)
+    ! record number of bytes written to this file
+    files(file)%bytes_written = files(file)%bytes_written +&
+         & (SIZE(dat,1)*SIZE(dat,2)*SIZE(dat,3))*(8/output_fields(field)%pack)
+    IF ( .NOT.output_fields(field)%written_once ) output_fields(field)%written_once = .TRUE.
+    ! *** inserted this line because start_dif < 0 for static fields ***
+    IF ( .NOT.output_fields(field)%static ) THEN
+       start_dif = get_date_dif(output_fields(field)%last_output, base_time,files(file)%time_units)
+       IF ( .NOT.mix_snapshot_average_fields ) THEN
+          end_dif = get_date_dif(output_fields(field)%next_output, base_time, files(file)%time_units)
+       ELSE
+          end_dif = dif
+       END IF
+    END IF
+
+    ! Need to write average axes out;
+    DO i = 1, files(file)%num_fields
+       num = files(file)%fields(i)
+       IF ( output_fields(num)%time_ops .AND. &
+            input_fields(output_fields(num)%input_field)%register) THEN
+          ! time needs to be between start_dif and end_dif to prevent duplicate writes on time_bounds
+          IF ( num == field ) THEN
+            IF ( files(file)%rtime_current >= start_dif .AND. files(file)%rtime_current <= end_dif) THEN
+             ! Output the axes if this is first time-averaged field
+             time_data(1, 1, 1, 1) = start_dif
+             call diag_field_write (files(file)%f_avg_start, time_data(1:1,:,:,:), file_num=file, &
+                                   fileobjU=fileobjU, fileobj=fileobj, fileobjND=fileobjND, &
+                                   fnum_for_domain=fnum_for_domain(file), time_in=files(file)%time_index)
+             time_data(2, 1, 1, 1) = end_dif
+             call diag_field_write (files(file)%f_avg_end, time_data(2:2,:,:,:), file_num=file, &
+                                   fileobjU=fileobjU, fileobj=fileobj, fileobjND=fileobjND, &
+                                   fnum_for_domain=fnum_for_domain(file), time_in=files(file)%time_index)
+             ! Compute the length of the average
+             dt_time(1, 1, 1, 1) = end_dif - start_dif
+             call diag_field_write (files(file)%f_avg_nitems, dt_time(1:1,:,:,:), file_num=file, &
+                                   fileobjU=fileobjU, fileobj=fileobj, fileobjND=fileobjND, &
+                                   fnum_for_domain=fnum_for_domain(file), time_in=files(file)%time_index)
+             ! Include boundary variable for CF compliance
+             call diag_field_write (files(file)%f_bounds, time_data(1:2,:,:,:), file_num=file, &
+                                   fileobjU=fileobjU, fileobj=fileobj, fileobjND=fileobjND, &
+                                   fnum_for_domain=fnum_for_domain(file), time_in=files(file)%time_index)
+             EXIT
+            END IF
+          END IF
+       END IF
+    END DO
+
+    ! If write time is greater (equal for the last call) than last_flush for this file, flush it
+    IF ( final_call ) THEN
+       IF ( time >= files(file)%last_flush ) THEN
+          files(file)%last_flush = time
+       END IF
+    ELSE
+       IF ( time > files(file)%last_flush .AND. (flush_nc_files.OR.debug_diag_manager) ) THEN
+          files(file)%last_flush = time
+       END IF
+    END IF
+  END SUBROUTINE diag_data_out
+
+  !> @brief Checks if it is time to open a new file.
+  !! @details Checks if it is time to open a new file. If yes, it first closes the
+  !!     current file, opens a new file and returns file_unit
+  !!     previous diag_manager_end is replaced by closing_file and output_setup by opening_file.
+  SUBROUTINE check_and_open(file, time, do_write, filename_time)
+    INTEGER, INTENT(in) :: file !<File ID.
+    TYPE(time_type), INTENT(in) :: time !< Current model time.
+    LOGICAL, INTENT(out) :: do_write !< <TT>.TRUE.</TT> if file is expecting more data to write,
+                                     !! <TT>.FALSE.</TT> otherwise.
+    TYPE(time_type), INTENT(in), optional :: filename_time !< Time used in setting the filename when writting periodic files
+
+    IF ( time >= files(file)%start_time ) THEN
+       IF ( files(file)%file_unit < 0 ) THEN ! need to open a new file
+          CALL opening_file(file, time, filename_time=filename_time)
+          do_write = .TRUE.
+       ELSE
+          do_write = .TRUE.
+          IF ( time > files(file)%close_time .AND. time < files(file)%next_open ) THEN
+             do_write = .FALSE. ! file still open but receives NO MORE data
+          ELSE IF ( time > files(file)%next_open ) THEN ! need to close current file and open a new one
+             CALL write_static(file)  ! write all static fields and close this file
+             CALL opening_file(file, time, filename_time=filename_time)
+             files(file)%time_index = 0 !< Reset the number of times in the files back to 0
+             files(file)%start_time = files(file)%next_open
+             files(file)%close_time =&
+                  & diag_time_inc(files(file)%start_time,files(file)%duration, files(file)%duration_units)
+             files(file)%next_open =&
+                  & diag_time_inc(files(file)%next_open, files(file)%new_file_freq,&
+                  & files(file)%new_file_freq_units)
+             IF ( files(file)%close_time > files(file)%next_open ) THEN
+                ! <ERROR STATUS="FATAL">
+                !   <file_name> has close time GREATER than next_open time,
+                !   check file duration and frequency
+                ! </ERROR>
+                CALL error_mesg('diag_util_mod::check_and_open',&
+                     & files(file)%name//' has close time GREATER than next_open time, check file duration and frequency',FATAL)
+             END IF
+          END IF ! no need to open new file, simply return file_unit
+       END IF
+    ELSE
+       do_write = .FALSE.
+    END IF
+  END SUBROUTINE check_and_open
+
+  !> @brief Output all static fields in this file
+  SUBROUTINE write_static(file)
+    INTEGER, INTENT(in) :: file !< File ID.
+    INTEGER :: j, i, input_num
+
+    DO j = 1, files(file)%num_fields
+       i = files(file)%fields(j)
+       input_num = output_fields(i)%input_field
+       ! skip fields that were not registered
+       IF ( .NOT.input_fields(input_num)%register ) CYCLE
+       IF ( output_fields(i)%local_output .AND. .NOT. output_fields(i)%need_compute) CYCLE
+       ! only output static fields here
+       IF ( .NOT.output_fields(i)%static ) CYCLE
+       CALL diag_data_out(file, i, output_fields(i)%buffer, files(file)%last_flush, .TRUE., .TRUE.)
+    END DO
+!! New FMS_IO close
+      ! File is stil open.  This is to protect when the diag_table has no Fields
+      ! going to this file, and it was never opened (b/c diag_data_out was not
+      ! called)
+      if (fnum_for_domain(file) == "2d" )then
+          if (check_if_open(fileobj(file))) call close_file (fileobj(file) )
+      elseif (fnum_for_domain(file) == "nd") then
+          if (check_if_open(fileobjND(file)) ) then
+               call close_file (fileobjND(file))
+          endif
+      elseif (fnum_for_domain(file) == "ug") then
+          if (check_if_open(fileobjU(file))) call close_file (fileobjU(file))
+      endif
+      files(file)%file_unit = -1
+  END SUBROUTINE write_static
+
+  !> @brief Checks to see if <TT>output_name</TT> and <TT>output_file</TT> are unique in <TT>output_fields</TT>.
+  SUBROUTINE check_duplicate_output_fields(err_msg)
+    CHARACTER(len=*), INTENT(out), OPTIONAL :: err_msg !< Error message.  If empty, then no duplicates found.
+
+    INTEGER :: i, j, tmp_file
+    CHARACTER(len=128) :: tmp_name
+    CHARACTER(len=256) :: err_msg_local
+
+    IF ( PRESENT(err_msg) ) err_msg=''
+    ! Do the checking when more than 1 output_fileds present
+    IF ( num_output_fields <= 1 ) RETURN
+    err_msg_local = ''
+
+    i_loop: DO i = 1, num_output_fields-1
+       tmp_name = TRIM(output_fields(i)%output_name)
+       tmp_file =  output_fields(i)%output_file
+       DO j = i+1, num_output_fields
+          IF ( (tmp_name == TRIM(output_fields(j)%output_name)) .AND. &
+               &(tmp_file == output_fields(j)%output_file)) THEN
+             err_msg_local = ' output_field "'//TRIM(tmp_name)//&
+                  &'" duplicated in file "'//TRIM(files(tmp_file)%name)//'"'
+             EXIT i_loop
+          END IF
+       END DO
+    END DO i_loop
+    IF ( err_msg_local /= '' ) THEN
+       IF ( fms_error_handler(' ERROR in diag_table',err_msg_local,err_msg) ) RETURN
+    END IF
+  END SUBROUTINE check_duplicate_output_fields
+
+  !> @brief Allocates the atttype in out_field
+  SUBROUTINE attribute_init_field(out_field, err_msg)
+    TYPE(output_field_type), INTENT(inout) :: out_field !< output field to allocate memory for attribute
+    CHARACTER(LEN=*), INTENT(out), OPTIONAL :: err_msg !< Error message, passed back to calling function
+
+    INTEGER :: istat
+
+    ! Need to initialize err_msg if present
+    IF ( PRESENT(err_msg) ) err_msg = ''
+
+    ! Allocate memory for the attributes
+    IF ( .NOT.allocated(out_field%attributes) ) THEN
+       ALLOCATE(out_field%attributes(max_field_attributes), STAT=istat)
+       IF ( istat.NE.0 ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   Unable to allocate memory for attribute <name> to module/input_field <module_name>/<field_name>
+          ! </ERROR>
+          IF ( fms_error_handler('diag_util_mod::attribute_init_field',&
+               & 'Unable to allocate memory for attributes', err_msg) ) THEN
+             RETURN
+          END IF
+       ELSE
+          ! Set equal to 0.  It will be increased when attributes added
+          out_field%num_attributes = 0
+       END IF
+    END IF
+  END SUBROUTINE attribute_init_field
+
+  !> @brief Prepends the attribute value to an already existing attribute.  If the
+  !!     attribute isn't yet defined, then creates a new attribute
+  SUBROUTINE prepend_attribute_field(out_field, att_name, prepend_value, err_msg)
+    TYPE(output_field_type), INTENT(inout) :: out_field !< output field that will get the attribute
+    CHARACTER(len=*), INTENT(in) :: att_name !< Name of the attribute
+    CHARACTER(len=*), INTENT(in) :: prepend_value !< Value to prepend
+    CHARACTER(len=*), INTENT(out) , OPTIONAL :: err_msg !< Error message, passed back to calling routine
+
+    INTEGER :: length, i, this_attribute
+    CHARACTER(len=512) :: err_msg_local
+
+    ! Initialize string characters
+    err_msg_local=''
+    IF ( PRESENT(err_msg) ) err_msg = ''
+
+    ! Make sure the attributes for this out field have been initialized
+    CALL attribute_init_field(out_field, err_msg_local)
+    IF ( TRIM(err_msg_local) .NE. '' ) THEN
+       IF ( fms_error_handler('diag_util_mod::prepend_attribute_field', TRIM(err_msg_local), err_msg) ) THEN
+          RETURN
+       END IF
+    END IF
+
+    ! Find if attribute exists
+    this_attribute = 0
+    DO i=1, out_field%num_attributes
+       IF ( TRIM(out_field%attributes(i)%name) .EQ. TRIM(att_name) ) THEN
+          this_attribute = i
+          EXIT
+       END IF
+    END DO
+
+    IF ( this_attribute > 0 ) THEN
+       IF ( out_field%attributes(this_attribute)%type .NE. NF90_CHAR ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   Attribute <name> is not a character attribute.
+          ! </ERROR>
+          IF ( fms_error_handler('diag_util_mod::prepend_attribute_field', &
+               & 'Attribute "'//TRIM(att_name)//'" is not a character attribute.',&
+               & err_msg) ) THEN
+             RETURN
+          END IF
+       END IF
+    ELSE
+       ! Defining a new attribute
+       ! Increase the number of field attributes
+       this_attribute = out_field%num_attributes + 1
+       IF ( this_attribute .GT. max_field_attributes ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   Number of attributes exceeds max_field_attributes for attribute <name>.
+          !   Increase diag_manager_nml:max_field_attributes.
+          ! </ERROR>
+          IF ( fms_error_handler('diag_util_mod::prepend_attribute_field',&
+               & 'Number of attributes exceeds max_field_attributes for attribute "'&
+               & //TRIM(att_name)//'".  Increase diag_manager_nml:max_field_attributes.',&
+               & err_msg) ) THEN
+             RETURN
+          END IF
+       ELSE
+          out_field%num_attributes = this_attribute
+          ! Set name and type
+          out_field%attributes(this_attribute)%name = att_name
+          out_field%attributes(this_attribute)%type = NF90_CHAR
+          ! Initialize catt to a blank string, as len_trim doesn't always work on an uninitialized string
+          out_field%attributes(this_attribute)%catt = ''
+       END IF
+    END IF
+
+    ! Check if string is already included, and return if found
+    IF ( INDEX(TRIM(out_field%attributes(this_attribute)%catt), TRIM(prepend_value)).EQ.0 ) THEN
+       ! Check if new string length goes beyond the length of catt
+       length = LEN_TRIM(TRIM(prepend_value)//" "//TRIM(out_field%attributes(this_attribute)%catt))
+       IF ( length.GT.LEN(out_field%attributes(this_attribute)%catt) ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   Prepend length for attribute <name> is longer than allowed.
+          ! </ERROR>
+          IF ( fms_error_handler('diag_util_mod::prepend_attribute_field',&
+               & 'Prepend length for attribute "'//TRIM(att_name)//'" is longer than allowed.',&
+               & err_msg) ) THEN
+             RETURN
+          END IF
+       END IF
+       ! Set fields
+       out_field%attributes(this_attribute)%catt =&
+            & TRIM(prepend_value)//' '//TRIM(out_field%attributes(this_attribute)%catt)
+       out_field%attributes(this_attribute)%len = length
+    END IF
+  END SUBROUTINE prepend_attribute_field
+  !> @brief Allocates the atttype in out_file
+  SUBROUTINE attribute_init_file(out_file, err_msg)
+    TYPE(file_type), INTENT(inout) :: out_file !< output file to allocate memory for attribute
+    CHARACTER(LEN=*), INTENT(out), OPTIONAL :: err_msg !< Error message, passed back to calling function
+
+    INTEGER :: istat
+
+    ! Initialize err_msg
+    IF ( PRESENT(err_msg) ) err_msg = ''
+
+    ! Allocate memory for the attributes
+    IF ( .NOT.allocated(out_file%attributes) ) THEN
+       ALLOCATE(out_file%attributes(max_field_attributes), STAT=istat)
+       IF ( istat.NE.0 ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   Unable to allocate memory for file attributes
+          ! </ERROR>
+          IF ( fms_error_handler('diag_util_mod::attribute_init_file', 'Unable to allocate memory for file attributes', err_msg) ) THEN
+             RETURN
+          END IF
+       ELSE
+          ! Set equal to 0.  It will be increased when attributes added
+          out_file%num_attributes = 0
+       END IF
+    END IF
+  END SUBROUTINE attribute_init_file
+
+  !> @brief Prepends the attribute value to an already existing attribute.  If the
+  !!     attribute isn't yet defined, then creates a new attribute
+  SUBROUTINE prepend_attribute_file(out_file, att_name, prepend_value, err_msg)
+    TYPE(file_type), INTENT(inout) :: out_file !< output file that will get the attribute
+    CHARACTER(len=*), INTENT(in) :: att_name !< Name of the attribute
+    CHARACTER(len=*), INTENT(in) :: prepend_value !< Value to prepend
+    CHARACTER(len=*), INTENT(out) , OPTIONAL :: err_msg !< Error message, passed back to calling routine
+
+    INTEGER :: length, i, this_attribute
+    CHARACTER(len=512) :: err_msg_local
+
+    ! Initialize string variables
+    err_msg_local = ''
+    IF ( PRESENT(err_msg) ) err_msg = ''
+
+    ! Make sure the attributes for this out file have been initialized
+    CALL attribute_init_file(out_file, err_msg_local)
+    IF ( TRIM(err_msg_local) .NE. '' ) THEN
+       IF ( fms_error_handler('diag_util_mod::prepend_attribute_file', TRIM(err_msg_local), err_msg) ) THEN
+          RETURN
+       END IF
+    END IF
+
+    ! Find if attribute exists
+    this_attribute = 0
+    DO i=1, out_file%num_attributes
+       IF ( TRIM(out_file%attributes(i)%name) .EQ. TRIM(att_name) ) THEN
+          this_attribute = i
+          EXIT
+       END IF
+    END DO
+
+    IF ( this_attribute > 0 ) THEN
+       IF ( out_file%attributes(this_attribute)%type .NE. NF90_CHAR ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   Attribute <name> is not a character attribute.
+          ! </ERROR>
+          IF ( fms_error_handler('diag_util_mod::prepend_attribute_file',&
+               & 'Attribute "'//TRIM(att_name)//'" is not a character attribute.',&
+               & err_msg) ) THEN
+             RETURN
+          END IF
+       END IF
+    ELSE
+       ! Defining a new attribute
+       ! Increase the number of file attributes
+       this_attribute = out_file%num_attributes + 1
+       IF ( this_attribute .GT. max_file_attributes ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   Number of attributes exceeds max_file_attributes for attribute <name>.
+          !   Increase diag_manager_nml:max_file_attributes.
+          ! </ERROR>
+          IF ( fms_error_handler('diag_util_mod::prepend_attribute_file',&
+               & 'Number of attributes exceeds max_file_attributes for attribute "'&
+               &//TRIM(att_name)//'".  Increase diag_manager_nml:max_file_attributes.',&
+               & err_msg) ) THEN
+             RETURN
+          END IF
+       ELSE
+          out_file%num_attributes = this_attribute
+          ! Set name and type
+          out_file%attributes(this_attribute)%name = att_name
+          out_file%attributes(this_attribute)%type = NF90_CHAR
+          ! Initialize catt to a blank string, as len_trim doesn't always work on an uninitialized string
+          out_file%attributes(this_attribute)%catt = ''
+       END IF
+    END IF
+
+    ! Only add string only if not already defined
+    IF ( INDEX(TRIM(out_file%attributes(this_attribute)%catt), TRIM(prepend_value)).EQ.0 ) THEN
+       ! Check if new string length goes beyond the length of catt
+       length = LEN_TRIM(TRIM(prepend_value)//" "//TRIM(out_file%attributes(this_attribute)%catt))
+       IF ( length.GT.LEN(out_file%attributes(this_attribute)%catt) ) THEN
+          ! <ERROR STATUS="FATAL">
+          !   Prepend length for attribute <name> is longer than allowed.
+          ! </ERROR>
+          IF ( fms_error_handler('diag_util_mod::prepend_attribute_file',&
+               & 'Prepend length for attribute "'//TRIM(att_name)//'" is longer than allowed.',&
+               & err_msg) ) THEN
+             RETURN
+          END IF
+       END IF
+       ! Set files
+       out_file%attributes(this_attribute)%catt =&
+            & TRIM(prepend_value)//' '//TRIM(out_file%attributes(this_attribute)%catt)
+       out_file%attributes(this_attribute)%len = length
+    END IF
+  END SUBROUTINE prepend_attribute_file
+
+END MODULE diag_util_mod
+!> @}
+! close documentation grouping


### PR DESCRIPTION
bounds metadata mods fix https://github.com/ESCOMP/MOM_interface/issues/107

New time and time:bounds metadata is
```
    double time(time) ;
      time:units = "days since 0001-01-01 00:00:00" ;
      time:long_name = "time" ;
      time:axis = "T" ;
      time:calendar = "noleap" ;
      time:bounds = "time_bounds" ;

    double time_bounds(time,nbnd) ;
      time_bounds:units = "days since 0001-01-01 00:00:00" ;
      time_bounds:long_name = "time interval endpoints" ;
      time_bounds:calendar = "noleap" ;
```

The date separator change goes with PR to https://github.com/ESCOMP/MOM_interface,
so that files with changed names get archived by short-term archiver and testing baseline generation works.
Once that PR is submitted, I will update this PR with a link to it.