### PR TITLE
Check NETCDF_SEPARATE before updating FLAGS

### DIFF
--- a/Makefile.cesm
+++ b/Makefile.cesm
@@ -172,8 +172,13 @@ else
   endif
   endif
 endif
-FFLAGS += -I$(INC_NETCDF)
-CFLAGS += -I$(INC_NETCDF)
+ifeq ($(NETCDF_SEPARATE), false)
+  FFLAGS += -I$(INC_NETCDF)
+  CFLAGS += -I$(INC_NETCDF)
+else
+  FFLAGS += -I$(INC_NETCDF_FORTRAN)
+  CFLAGS += -I$(INC_NETCDF_C)
+endif
 
 # Set HAVE_SLASHPROC on LINUX systems which are not bluegene or Darwin (OSx)
 


### PR DESCRIPTION
IF `NETCDF_SEPARATE` is true, then we want

```
FFLAGS += -I$(INC_NETCDF_FORTRAN)
CFLAGS += -I$(INC_NETCDF_C)
```

rather than adding `-I$(INC_NETCDF)` to both of them (because `INC_NETCDF` is empty in that case)