### PR TITLE
remove manage externals, add fms as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src"]
+	path = src
+	url = https://github.com/NOAA-GFDL/FMS

--- a/Externals_FMS.cfg
+++ b/Externals_FMS.cfg
@@ -1,9 +1,0 @@
-[fms]
-tag = xanadu
-protocol = git
-repo_url = https://github.com/NOAA-GFDL/FMS
-local_path = src
-required = True
-
-[externals_description]
-schema_version = 1.0.0


### PR DESCRIPTION
Need one branch for CAM and another for cesm since fv3 is still using an older fms version.
This removes the requirement for manage_externals