### PR TITLE
remove manage externals, replace with git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "fms"]
+path = src
+url = https://github.com/ESCOMP/FMS
+fxtag = dev/ncar_0.0.1
+fxrequired = AlwaysRequired
+fxDONOTUSEurl = https://github.com/ESCOMP/FMS

--- a/Externals_FMS.cfg
+++ b/Externals_FMS.cfg
@@ -1,9 +1,0 @@
-[fms]
-tag = dev/ncar_0.0.1
-protocol = git
-repo_url = https://github.com/ESCOMP/FMS
-local_path = src
-required = True
-
-[externals_description]
-schema_version = 1.0.0


### PR DESCRIPTION
Removes manage externals and adds fms as a submodule.  This is to support the cesm switch to git-fleximod.